### PR TITLE
refactor: replace interface{} with any across non-generated Go files

### DIFF
--- a/internal/bpf/events_test.go
+++ b/internal/bpf/events_test.go
@@ -332,7 +332,7 @@ func TestFileEventStrings(t *testing.T) {
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 // marshalLE serializes v into a byte slice using little-endian encoding.
-func marshalLE(t *testing.T, v interface{}) []byte {
+func marshalLE(t *testing.T, v any) []byte {
 	t.Helper()
 	size := binary.Size(v)
 	if size < 0 {
@@ -347,7 +347,7 @@ func marshalLE(t *testing.T, v interface{}) []byte {
 }
 
 // unmarshalLE deserializes buf into v using little-endian encoding.
-func unmarshalLE(t *testing.T, buf []byte, v interface{}) {
+func unmarshalLE(t *testing.T, buf []byte, v any) {
 	t.Helper()
 	_, err := binary.Decode(buf, binary.LittleEndian, v)
 	if err != nil {

--- a/internal/cli/live_render.go
+++ b/internal/cli/live_render.go
@@ -80,7 +80,7 @@ func liveFooter(w io.Writer, s liveStyle, eventsCaptured uint64, elapsed time.Du
 
 // liveColumnHeader formats a row of column labels in cyan-bold so
 // header lines are visually distinct from data rows.
-func liveColumnHeader(s liveStyle, format string, args ...interface{}) string {
+func liveColumnHeader(s liveStyle, format string, args ...any) string {
 	row := fmt.Sprintf(format, args...)
 	if !s.color {
 		return row

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -234,7 +234,7 @@ func healthzHandler(loaded, total int) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"status":         "ok",
 			"programsLoaded": loaded,
 			"programsTotal":  total,

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -31,7 +31,7 @@ type Collector interface {
 
 	// Snapshot returns a point-in-time copy of the aggregated signals.
 	// The returned value is safe for concurrent read by other goroutines.
-	Snapshot() interface{}
+	Snapshot() any
 }
 
 // Registry manages the lifecycle of multiple collectors.

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -16,7 +16,7 @@ type fakeCollector struct {
 	name    string
 	started bool
 	stopped bool
-	snap    interface{}
+	snap    any
 	startFn func() error
 }
 
@@ -32,7 +32,7 @@ func (f *fakeCollector) Start(_ context.Context) error {
 
 func (f *fakeCollector) Stop() { f.stopped = true }
 
-func (f *fakeCollector) Snapshot() interface{} { return f.snap }
+func (f *fakeCollector) Snapshot() any { return f.snap }
 
 // ─── Registry Tests ─────────────────────────────────────────────────────────
 

--- a/internal/collector/disk.go
+++ b/internal/collector/disk.go
@@ -116,7 +116,7 @@ func (c *DiskIOCollector) record(event *bpf.DiskEvent) {
 }
 
 // Snapshot implements Collector. Returns *DiskIOSnapshot.
-func (c *DiskIOCollector) Snapshot() interface{} {
+func (c *DiskIOCollector) Snapshot() any {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/collector/fd.go
+++ b/internal/collector/fd.go
@@ -138,7 +138,7 @@ func (c *FDCollector) record(event *bpf.FDEvent) {
 }
 
 // Snapshot implements Collector. Returns *FDSnapshot.
-func (c *FDCollector) Snapshot() interface{} {
+func (c *FDCollector) Snapshot() any {
 	c.mu.Lock()
 	totalOpens := c.totalOpens
 	totalCloses := c.totalCloses

--- a/internal/collector/memory.go
+++ b/internal/collector/memory.go
@@ -173,7 +173,7 @@ func (c *MemoryCollector) poll() error {
 }
 
 // Snapshot implements Collector. Returns *MemorySnapshot.
-func (c *MemoryCollector) Snapshot() interface{} {
+func (c *MemoryCollector) Snapshot() any {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.have {

--- a/internal/collector/memory_test.go
+++ b/internal/collector/memory_test.go
@@ -98,7 +98,7 @@ func TestCollectorMemoryHighCardinalityBurst(t *testing.T) {
 
 	// Force snapshots to ensure they don't reveal hidden allocations.
 	for _, snapper := range []interface {
-		Snapshot() interface{}
+		Snapshot() any
 	}{sc, tc, oc, dc, schc, fc} {
 		_ = snapper.Snapshot()
 	}

--- a/internal/collector/oom.go
+++ b/internal/collector/oom.go
@@ -113,7 +113,7 @@ func (c *OOMCollector) record(event *bpf.OOMEvent) {
 }
 
 // Snapshot implements Collector. Returns *OOMSnapshot.
-func (c *OOMCollector) Snapshot() interface{} {
+func (c *OOMCollector) Snapshot() any {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/collector/sched.go
+++ b/internal/collector/sched.go
@@ -131,7 +131,7 @@ func (c *SchedCollector) record(event *bpf.SchedEvent) {
 }
 
 // Snapshot implements Collector. Returns *SchedSnapshot.
-func (c *SchedCollector) Snapshot() interface{} {
+func (c *SchedCollector) Snapshot() any {
 	c.mu.Lock()
 	total := c.total
 	globalSnap := c.global.Snapshot()

--- a/internal/collector/syscall.go
+++ b/internal/collector/syscall.go
@@ -139,7 +139,7 @@ func (c *SyscallCollector) record(event *bpf.SyscallEvent) {
 }
 
 // Snapshot implements Collector. Returns *SyscallSnapshot.
-func (c *SyscallCollector) Snapshot() interface{} {
+func (c *SyscallCollector) Snapshot() any {
 	c.mu.Lock()
 	total := c.totalCount
 	entries := make([]SyscallEntry, 0, c.keys.Len())

--- a/internal/collector/tcp.go
+++ b/internal/collector/tcp.go
@@ -166,7 +166,7 @@ func (c *TCPCollector) record(event *bpf.TCPEvent) {
 }
 
 // Snapshot implements Collector. Returns *TCPSnapshot.
-func (c *TCPCollector) Snapshot() interface{} {
+func (c *TCPCollector) Snapshot() any {
 	c.mu.Lock()
 	totalEvents := c.totalEvents
 	totalRetransmits := c.totalRetransmits

--- a/internal/doctor/finding.go
+++ b/internal/doctor/finding.go
@@ -133,13 +133,13 @@ type Report struct {
 	ProgramsLoaded  int
 
 	// Analysis is the optional AI-enhanced analysis (nil if AI disabled).
-	Analysis interface{}
+	Analysis any
 
 	// Signals is the raw signal snapshot the rules were evaluated against.
 	// Populated for debug/observability — JSON renderer emits it under
 	// the "signals" key so operators can verify thresholds against
 	// observed values. Pretty renderer ignores it.
-	Signals interface{} `json:"-"`
+	Signals any `json:"-"`
 
 	// Environment describes how kerno is running (kubernetes, systemd,
 	// baremetal). Used by the pretty renderer to add context to the

--- a/internal/doctor/render.go
+++ b/internal/doctor/render.go
@@ -596,7 +596,7 @@ type jsonReport struct {
 	Findings  []jsonFinding     `json:"findings"`
 	Summary   reportSummary     `json:"summary"`
 	Analysis  *AnalysisResponse `json:"analysis,omitempty"`
-	Signals   interface{}       `json:"signals,omitempty"`
+	Signals   any               `json:"signals,omitempty"`
 }
 
 type jsonFinding struct {


### PR DESCRIPTION
Go 1.18 introduced any as a type alias for interface{}. Updated ~30 occurrences across internal packages.

Skipped: *_bpfel.go and *_bpfeb.go (code-generated files)

Closes #13

<!--
Thanks for contributing to Kerno! A few notes:

- PR title must follow Conventional Commits: `feat(scope): subject` (linted in CI).
- Every commit must be DCO-signed (`git commit -s`).
- Squash merges are the default — your PR title becomes the merge commit.
- CI runs build + race tests + lint + (when configured) the kernel matrix.
-->

## What

Replace all `interface{}` occurrences with `any` across non-generated Go files. 
~30 mechanical substitutions, no semantic changes.

## Why


Fixes #13

## How

Used PowerShell string replacement across all *.go files, 
skipping *_bpfel.go and *_bpfeb.go (code-generated by bpf2go).
Updated doc comment on `Collector.Snapshot()` accordingly.
No logic changes — purely syntactic modernisation for Go 1.18+.

## Testing

- [ ✅\] `go build ./...` passes
- [ ✅] `go test ./...` passes
- [✅ ] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] Tested locally with: <!-- e.g. `sudo ./bin/kerno doctor --duration 5s` -->

<!-- Required for changes touching internal/bpf/, internal/collector/, internal/doctor/. -->

- [✅ ] N/A — pure docs/refactor
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [✅ ] PR title follows Conventional Commits (`feat(scope): subject`)
- [✅ ] All commits are DCO-signed (`git commit -s`)
- [ ✅] No unrelated changes pulled in
- [ ] Documentation updated where user-visible behavior changed
- [ ] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`
