### PR TITLE
feat(cli): add shell completion for bash, zsh, fish, powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,52 @@ docker run --rm --privileged --pid=host \
 
 Multi-arch (`linux/amd64`, `linux/arm64`) images published to GHCR on every release.
 
+### Shell Completion
+
+Enable tab completion for your shell:
+
+**Bash:**
+
+```bash
+# Load completions for current session
+source <(kerno completion bash)
+
+# Persist across sessions
+echo 'source <(kerno completion bash)' >> ~/.bashrc
+```
+
+**Zsh:**
+
+```bash
+# Enable completions (add to ~/.zshrc if not already present)
+echo 'autoload -U compinit; compinit' >> ~/.zshrc
+
+# Load completions for current session
+autoload -U compinit && compinit
+kerno completion zsh > "${fpath[1]}/_kerno"
+
+# Persist across sessions - run once, then start new shell
+kerno completion zsh > "${fpath[1]}/_kerno"
+```
+
+**Fish:**
+
+```bash
+# Load completions for current session
+kerno completion fish | source
+
+# Persist across sessions
+kerno completion fish > ~/.config/fish/completions/kerno.fish
+```
+
+**PowerShell:**
+
+```powershell
+# Add to your PowerShell profile
+kerno completion powershell > kerno.ps1
+. ./kerno.ps1
+```
+
 ---
 
 ## Kubernetes Deployment

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -4,8 +4,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
@@ -64,13 +62,13 @@ Alternatively, specify the shell with the first argument:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
 			case "bash":
-				return cmd.Root().GenBashCompletion(os.Stdout)
+				return cmd.Root().GenBashCompletion(cmd.OutOrStdout())
 			case "zsh":
-				return cmd.Root().GenZshCompletion(os.Stdout)
+				return cmd.Root().GenZshCompletion(cmd.OutOrStdout())
 			case "fish":
-				return cmd.Root().GenFishCompletion(os.Stdout, true)
+				return cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true)
 			case "powershell":
-				return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+				return cmd.Root().GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
 			}
 			return nil
 		},

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for kerno.
+
+Kerno uses spf13/cobra's built-in completion generation which supports
+bash, zsh, fish, and powershell.
+
+To load completions:
+
+Bash:
+
+  $ source <(kerno completion bash)
+
+  # To load completions for each session, execute once:
+  $ echo 'source <(kerno completion bash)' >> ~/.bashrc
+
+Zsh:
+
+  # If shell completion is not already enabled in your zsh environment,
+  # you need to enable it.  You can execute the following once:
+
+  $ echo 'autoload -U compinit; compinit' >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ kerno completion zsh > "${fpath[1]}/_kerno"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+  $ kerno completion fish | source
+
+  # To load completions for each session, execute once:
+  $ kerno completion fish > ~/.config/fish/completions/kerno.fish
+
+PowerShell:
+
+  PS> kerno completion powershell > kerno.ps1
+  # and source this file from your PowerShell profile.
+
+Alternatively, specify the shell with the first argument:
+
+  $ kerno completion bash
+  $ kerno completion zsh
+  $ kerno completion fish
+  $ kerno completion powershell
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactArgs(1),
+		Hidden:                true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "bash":
+				return cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				return cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				return cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -61,7 +61,6 @@ Alternatively, specify the shell with the first argument:
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.ExactArgs(1),
-		Hidden:                true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
 			case "bash":

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCompletionCmd(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			cmd := New()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetArgs([]string{"completion", shell})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("%s: %v", shell, err)
+			}
+			if buf.Len() == 0 {
+				t.Errorf("%s: empty completion output", shell)
+			}
+		})
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -94,6 +94,11 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
 	flags.BoolVar(&noAI, "no-ai", false, "disable AI analysis even if enabled in config")
 	flags.BoolVarP(&quiet, "quiet", "q", false, "only emit critical/warning findings (CI-friendly)")
 
+	//nolint:errcheck // RegisterFlagCompletionFunc only returns error on invalid flag name, which is static.
+	_ = cmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"pretty", "json"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
 	return cmd
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -83,6 +83,7 @@ and copy-paste fix steps.`,
 	auditCmd := newAuditCmd()
 	chaosCmd := newChaosCmd()
 	versionCmd := newVersionCmd()
+	completionCmd := newCompletionCmd()
 
 	root.AddGroup(
 		&cobra.Group{ID: "diagnose", Title: "Incident diagnosis:"},
@@ -98,8 +99,9 @@ and copy-paste fix steps.`,
 	startCmd.GroupID = "ops"
 	chaosCmd.GroupID = "ops"
 	versionCmd.GroupID = "ops"
+	completionCmd.GroupID = "ops"
 
-	root.AddCommand(doctorCmd, explainCmd, predictCmd, traceCmd, watchCmd, auditCmd, startCmd, chaosCmd, versionCmd)
+	root.AddCommand(doctorCmd, explainCmd, predictCmd, traceCmd, watchCmd, auditCmd, startCmd, chaosCmd, versionCmd, completionCmd)
 
 	return root
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -126,15 +126,11 @@ install_completion() {
             echo "    Restart shell or run: source ${bash_dir}/kerno"
             ;;
         zsh)
-            local zsh_dir="${ZDOTDIR:-$HOME}"
-            local comp_file="${zsh_dir}/completions/_kerno"
-            mkdir -p "${zsh_dir}/completions"
-            kerno completion zsh > "$comp_file"
-            chmod 644 "$comp_file"
-            echo "    Installed to $comp_file"
-            if ! grep -q "autoload -U compinit" "${zsh_dir}/.zshrc" 2>/dev/null; then
-                echo 'autoload -U compinit && compinit' >> "${zsh_dir}/.zshrc"
-            fi
+            local zsh_dir="/usr/local/share/zsh/site-functions"
+            mkdir -p "$zsh_dir"
+            kerno completion zsh > "${zsh_dir}/_kerno"
+            chmod 644 "${zsh_dir}/_kerno"
+            echo "    Installed to ${zsh_dir}/_kerno"
             echo "    Restart shell or run: autoload -U compinit && compinit"
             ;;
         fish)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -120,7 +120,7 @@ install_completion() {
         bash)
             local bash_dir="/etc/bash_completion.d"
             mkdir -p "$bash_dir"
-            kerno completion bash > "${bash_dir}/kerno"
+            "${INSTALL_DIR}/kerno" completion bash > "${bash_dir}/kerno"
             chmod 644 "${bash_dir}/kerno"
             echo "    Installed to ${bash_dir}/kerno"
             echo "    Restart shell or run: source ${bash_dir}/kerno"
@@ -128,7 +128,7 @@ install_completion() {
         zsh)
             local zsh_dir="/usr/local/share/zsh/site-functions"
             mkdir -p "$zsh_dir"
-            kerno completion zsh > "${zsh_dir}/_kerno"
+            "${INSTALL_DIR}/kerno" completion zsh > "${zsh_dir}/_kerno"
             chmod 644 "${zsh_dir}/_kerno"
             echo "    Installed to ${zsh_dir}/_kerno"
             echo "    Restart shell or run: autoload -U compinit && compinit"
@@ -136,7 +136,7 @@ install_completion() {
         fish)
             local fish_dir="/usr/share/fish/vendor_completions.d"
             mkdir -p "$fish_dir"
-            kerno completion fish > "${fish_dir}/kerno.fish"
+            "${INSTALL_DIR}/kerno" completion fish > "${fish_dir}/kerno.fish"
             chmod 644 "${fish_dir}/kerno.fish"
             echo "    Installed to ${fish_dir}/kerno.fish"
             echo "    Restart fish to load the new completion"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -134,12 +134,12 @@ install_completion() {
             echo "    Restart shell or run: autoload -U compinit && compinit"
             ;;
         fish)
-            local fish_dir="${HOME}/.config/fish/completions"
+            local fish_dir="/usr/share/fish/vendor_completions.d"
             mkdir -p "$fish_dir"
             kerno completion fish > "${fish_dir}/kerno.fish"
             chmod 644 "${fish_dir}/kerno.fish"
             echo "    Installed to ${fish_dir}/kerno.fish"
-            echo "    Restart fish or run: source ${fish_dir}/kerno.fish"
+            echo "    Restart fish to load the new completion"
             ;;
     esac
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,17 +30,20 @@ CONFIG_DIR="/etc/kerno"
 # ── Parse arguments ──────────────────────────────────────────────────
 VERSION=""
 INSTALL_DAEMON=false
+INSTALL_COMPLETION=true
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --version) VERSION="$2"; shift 2 ;;
         --daemon)  INSTALL_DAEMON=true; shift ;;
+        --no-completion) INSTALL_COMPLETION=false; shift ;;
         --help|-h)
             echo "Usage: curl -sfL https://raw.githubusercontent.com/optiqor/kerno/main/scripts/install.sh | bash -s -- [OPTIONS]"
             echo ""
             echo "Options:"
             echo "  --version VERSION   Install a specific version (default: latest)"
             echo "  --daemon            Also install systemd service for daemon mode"
+            echo "  --no-completion     Skip shell completion installation"
             echo "  --help              Show this help"
             exit 0
             ;;
@@ -86,6 +89,63 @@ check_root() {
         echo "Re-run with: curl -sfL https://raw.githubusercontent.com/optiqor/kerno/main/scripts/install.sh | sudo bash"
         exit 1
     fi
+}
+
+# ── Shell completion installation ──────────────────────────────────
+detect_shell() {
+    local shell
+    shell="${SHELL##*/}"
+    case "$shell" in
+        bash) echo "bash" ;;
+        zsh)  echo "zsh"  ;;
+        fish) echo "fish" ;;
+        *)    echo "" ;;
+    esac
+}
+
+install_completion() {
+    local shell
+    shell=$(detect_shell)
+
+    if [ -z "$shell" ]; then
+        echo "==> Shell completion: could not detect shell (SHELL=$SHELL)"
+        echo "    Manually enable completion: https://github.com/optiqor/kerno#shell-completion"
+        return
+    fi
+
+    echo ""
+    echo "==> Installing shell completion for $shell..."
+
+    case "$shell" in
+        bash)
+            local bash_dir="/etc/bash_completion.d"
+            mkdir -p "$bash_dir"
+            kerno completion bash > "${bash_dir}/kerno"
+            chmod 644 "${bash_dir}/kerno"
+            echo "    Installed to ${bash_dir}/kerno"
+            echo "    Restart shell or run: source ${bash_dir}/kerno"
+            ;;
+        zsh)
+            local zsh_dir="${ZDOTDIR:-$HOME}"
+            local comp_file="${zsh_dir}/completions/_kerno"
+            mkdir -p "${zsh_dir}/completions"
+            kerno completion zsh > "$comp_file"
+            chmod 644 "$comp_file"
+            echo "    Installed to $comp_file"
+            if ! grep -q "autoload -U compinit" "${zsh_dir}/.zshrc" 2>/dev/null; then
+                echo 'autoload -U compinit && compinit' >> "${zsh_dir}/.zshrc"
+            fi
+            echo "    Restart shell or run: autoload -U compinit && compinit"
+            ;;
+        fish)
+            local fish_dir="${HOME}/.config/fish/completions"
+            mkdir -p "$fish_dir"
+            kerno completion fish > "${fish_dir}/kerno.fish"
+            chmod 644 "${fish_dir}/kerno.fish"
+            echo "    Installed to ${fish_dir}/kerno.fish"
+            echo "    Restart fish or run: source ${fish_dir}/kerno.fish"
+            ;;
+    esac
 }
 
 # ── Download ─────────────────────────────────────────────────────────
@@ -142,7 +202,12 @@ main() {
 
     echo "==> Installed: $(kerno version 2>/dev/null || echo "${INSTALL_DIR}/kerno")"
 
-    # ── Optional: systemd daemon ─────────────────────────────────────
+    # ── Optional: shell completion ────────────────────────────────────
+    if [ "$INSTALL_COMPLETION" = true ]; then
+        install_completion
+    fi
+
+    # ── Optional: systemd daemon ───────────────────────────────────────
     if [ "$INSTALL_DAEMON" = true ]; then
         echo ""
         echo "==> Installing systemd service..."


### PR DESCRIPTION
- Add kerno completion <bash|zsh|fish|powershell> command
- Auto-detect shell in install.sh and install completion
- Register --output flag values (pretty/json) for tab completion
- Update README with shell-specific setup instructions
- Mark completion command as hidden (plumbing, not feature)

<!--
Thanks for contributing to Kerno! A few notes:

- PR title must follow Conventional Commits: `feat(scope): subject` (linted in CI).
- Every commit must be DCO-signed (`git commit -s`).
- Squash merges are the default — your PR title becomes the merge commit.
- CI runs build + race tests + lint + (when configured) the kernel matrix.
-->

## What
Add `kerno completion <bash|zsh|fish|powershell>` command that generates shell completion scripts, enabling tab-completion for subcommands, flags, and known flag values.

## Why
Cobra-based tools (kubectl, docker, helm) ship with an explicit completion command. Kerno didn't, so tab-completion didn't work — `kerno tr` wouldn't suggest `trace`, `kerno doctor --out` wouldn't suggest `--output`.

https://github.com/optiqor/kerno/issues/39

Fixes #

## How
- Created `internal/cli/completion.go` wrapping Cobra's built-in generators (GenBashCompletion, GenZshCompletion, GenFishCompletion, GenPowerShellCompletionWithDesc)
- Registered command under "ops" group, marked as hidden (plumbing, not feature)
- Added `--output` flag completion values (pretty, json) via RegisterFlagCompletionFunc
- Updated `scripts/install.sh` to auto-detect shell and install completion to appropriate location
- Added "Shell Completion" section to README with shell-specific instructions

<!-- Notable design decisions, tradeoffs, or implementation notes. Keep it short. -->

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Tested locally with: <!-- e.g. `sudo ./bin/kerno doctor --duration 5s` -->

<!-- Required for changes touching internal/bpf/, internal/collector/, internal/doctor/. -->

- [ ] N/A — pure docs/refactor
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed
- [x] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`
