### PR TITLE
feat: extend formatBytes to support TB and PB units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ BRAND_TODO.md
 # Root binary
 /kerno
 .claude
+mess-food-feedback-analyzer/

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,3 @@ BRAND_TODO.md
 # Root binary
 /kerno
 .claude
-mess-food-feedback-analyzer/

--- a/internal/cli/bpfutil.go
+++ b/internal/cli/bpfutil.go
@@ -52,6 +52,10 @@ func formatLatency(d time.Duration) string {
 // formatBytes renders a byte count as a human-friendly string.
 func formatBytes(b uint64) string {
 	switch {
+	case b >= 1<<50:
+        return fmt.Sprintf("%.1fPB", float64(b)/(1<<50))
+    case b >= 1<<40:
+        return fmt.Sprintf("%.1fTB", float64(b)/(1<<40))
 	case b >= 1<<30:
 		return fmt.Sprintf("%.1fGB", float64(b)/(1<<30))
 	case b >= 1<<20:

--- a/internal/cli/bpfutil.go
+++ b/internal/cli/bpfutil.go
@@ -53,9 +53,9 @@ func formatLatency(d time.Duration) string {
 func formatBytes(b uint64) string {
 	switch {
 	case b >= 1<<50:
-        return fmt.Sprintf("%.1fPB", float64(b)/(1<<50))
-    case b >= 1<<40:
-        return fmt.Sprintf("%.1fTB", float64(b)/(1<<40))
+		return fmt.Sprintf("%.1fPB", float64(b)/(1<<50))
+	case b >= 1<<40:
+		return fmt.Sprintf("%.1fTB", float64(b)/(1<<40))
 	case b >= 1<<30:
 		return fmt.Sprintf("%.1fGB", float64(b)/(1<<30))
 	case b >= 1<<20:

--- a/internal/cli/trace_test.go
+++ b/internal/cli/trace_test.go
@@ -197,6 +197,8 @@ func TestFormatBytes(t *testing.T) {
 		{"kilobytes", 4096, "4.0KB"},
 		{"megabytes", 1048576, "1.0MB"},
 		{"gigabytes", 1073741824, "1.0GB"},
+		{"terabytes", 1 << 40, "1.0TB"},
+		{"petabytes", 1 << 50, "1.0PB"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/doctor/rules.go
+++ b/internal/doctor/rules.go
@@ -503,8 +503,14 @@ func formatBytes(b uint64) string {
 		kB = 1024
 		mB = kB * 1024
 		gB = mB * 1024
+		tB = gB * 1024
+		pB = tB * 1024
 	)
 	switch {
+	case b >= pB:
+		return fmt.Sprintf("%.1fPB", float64(b)/float64(pB))
+	case b >= tB:
+		return fmt.Sprintf("%.1fTB", float64(b)/float64(tB))
 	case b >= gB:
 		return fmt.Sprintf("%.1fGB", float64(b)/float64(gB))
 	case b >= mB:

--- a/internal/doctor/rules_test.go
+++ b/internal/doctor/rules_test.go
@@ -477,20 +477,20 @@ func TestEvaluate_MultipleFindings(t *testing.T) {
 }
 
 func TestFormatBytes(t *testing.T) {
-cases := []struct {
-in   uint64
-want string
-}{
-{512, "512B"},
-{4096, "4.0KB"},
-{1 << 20, "1.0MB"},
-{1 << 30, "1.0GB"},
-{1 << 40, "1.0TB"},
-{1 << 50, "1.0PB"},
-}
-for _, c := range cases {
-if got := formatBytes(c.in); got != c.want {
-t.Errorf("formatBytes(%d) = %q, want %q", c.in, got, c.want)
-}
-}
+	cases := []struct {
+		in   uint64
+		want string
+	}{
+		{512, "512B"},
+		{4096, "4.0KB"},
+		{1 << 20, "1.0MB"},
+		{1 << 30, "1.0GB"},
+		{1 << 40, "1.0TB"},
+		{1 << 50, "1.0PB"},
+	}
+	for _, c := range cases {
+		if got := formatBytes(c.in); got != c.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
 }

--- a/internal/doctor/rules_test.go
+++ b/internal/doctor/rules_test.go
@@ -475,3 +475,22 @@ func TestEvaluate_MultipleFindings(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatBytes(t *testing.T) {
+cases := []struct {
+in   uint64
+want string
+}{
+{512, "512B"},
+{4096, "4.0KB"},
+{1 << 20, "1.0MB"},
+{1 << 30, "1.0GB"},
+{1 << 40, "1.0TB"},
+{1 << 50, "1.0PB"},
+}
+for _, c := range cases {
+if got := formatBytes(c.in); got != c.want {
+t.Errorf("formatBytes(%d) = %q, want %q", c.in, got, c.want)
+}
+}
+}


### PR DESCRIPTION
Closes #12 

## Changes
- Added TB and PB cases to formatBytes in internal/cli/bpfutil.go
- Added TB and PB cases to formatBytes in internal/doctor/rules.go
- Added terabytes and petabytes test cases in internal/cli/trace_test.go

## Notes
eBPF-dependent packages fail on Windows due to Linux-only kernel 
dependencies — this is a pre-existing issue unrelated to this change.