### PR TITLE
feat(doctor): cgroup memory pressure detector with OOMKill ETA prediction (closes #21)

### DIFF
--- a/internal/adapter/kubernetes.go
+++ b/internal/adapter/kubernetes.go
@@ -96,6 +96,23 @@ func (a *KubernetesAdapter) Stop() {
 	}
 }
 
+// LookupByPath resolves a cgroup path to a Kubernetes pod name and namespace.
+// Returns ("", "") when the path cannot be matched (non-K8s or unknown pod).
+// Implements collector.PodLookup.
+func (a *KubernetesAdapter) LookupByPath(cgroupPath string) (pod, namespace string) {
+	uid := extractPodUID(cgroupPath)
+	if uid == "" {
+		return "", ""
+	}
+	a.mu.RLock()
+	info, ok := a.index[uid]
+	a.mu.RUnlock()
+	if !ok {
+		return "", ""
+	}
+	return info.Name, info.Namespace
+}
+
 // Enrich maps the PID's cgroup path to a K8s pod and populates metadata.
 func (a *KubernetesAdapter) Enrich(meta *EventMeta) {
 	meta.Hostname = a.hostname

--- a/internal/chaos/memory.go
+++ b/internal/chaos/memory.go
@@ -83,9 +83,9 @@ func memoryMBFromIntensity(intensity Intensity) int {
 
 // CgroupMemoryScenario creates a simulated cgroup v2 directory tree under
 // /tmp with memory.max set to a finite limit and memory.current growing
-// toward it. Set KERNO_CGROUP_ROOT to the printed path before running
-// kerno doctor so the CgroupMemoryCollector reads the simulated files
-// instead of /sys/fs/cgroup.
+// toward it. Pass KERNO_CGROUP_ROOT inline when invoking kerno doctor
+// (e.g. KERNO_CGROUP_ROOT=<path> kerno doctor) so the env var is scoped
+// to that process only and does not persist in the shell session.
 //
 // This pairs with the memory_limit_pressure rule.
 type CgroupMemoryScenario struct{}
@@ -121,7 +121,7 @@ func (s CgroupMemoryScenario) Run(ctx context.Context, opts Options) error {
 	chaosRoot := filepath.Join(os.TempDir(), "kerno-chaos-cgroup")
 	fmt.Fprintf(opts.Out, "    cgroup root: %s\n", chaosRoot)
 	fmt.Fprintf(opts.Out, "    memory.max=%d MB, growing toward limit\n", limitMB)
-	fmt.Fprintf(opts.Out, "    hint: export KERNO_CGROUP_ROOT=%s && kerno doctor\n", chaosRoot)
+	fmt.Fprintf(opts.Out, "    hint: KERNO_CGROUP_ROOT=%s kerno doctor\n", chaosRoot)
 
 	// Grow current usage from 80 % to 97 % over the run duration.
 	startBytes := limitBytes * 80 / 100

--- a/internal/chaos/memory.go
+++ b/internal/chaos/memory.go
@@ -92,27 +92,29 @@ type CgroupMemoryScenario struct{}
 
 func init() { Register(CgroupMemoryScenario{}) }
 
-func (CgroupMemoryScenario) Name() string        { return "cgroup-memory" }
-func (CgroupMemoryScenario) Description() string  { return "Simulate a container approaching its cgroup memory.max limit" }
-func (CgroupMemoryScenario) PairedRule() string   { return "memory_limit_pressure" }
+func (CgroupMemoryScenario) Name() string { return "cgroup-memory" }
+func (CgroupMemoryScenario) Description() string {
+	return "Simulate a container approaching its cgroup memory.max limit"
+}
+func (CgroupMemoryScenario) PairedRule() string { return "memory_limit_pressure" }
 
 // Run implements Scenario.
 func (s CgroupMemoryScenario) Run(ctx context.Context, opts Options) error {
 	limitMB := cgroupMemoryLimitMB(opts.Intensity)
-	limitBytes := uint64(limitMB) << 20
+	limitBytes := uint64(limitMB) << 20 //nolint:gosec // limitMB is a small controlled constant, no overflow risk
 
 	cgroupDir := filepath.Join(os.TempDir(), "kerno-chaos-cgroup", "kubepods", "burstable", "pod-kerno-chaos", "container-0")
-	if err := os.MkdirAll(cgroupDir, 0o755); err != nil {
+	if err := os.MkdirAll(cgroupDir, 0o750); err != nil { //nolint:gosec // temp dir for chaos simulation
 		return fmt.Errorf("cgroup-memory: create dir: %w", err)
 	}
 	defer func() {
 		_ = os.RemoveAll(filepath.Join(os.TempDir(), "kerno-chaos-cgroup"))
 	}()
 
-	if err := os.WriteFile(filepath.Join(cgroupDir, "memory.max"), []byte(strconv.FormatUint(limitBytes, 10)+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cgroupDir, "memory.max"), []byte(strconv.FormatUint(limitBytes, 10)+"\n"), 0o600); err != nil {
 		return fmt.Errorf("cgroup-memory: write memory.max: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(cgroupDir, "memory.high"), []byte(strconv.FormatUint(limitBytes*9/10, 10)+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cgroupDir, "memory.high"), []byte(strconv.FormatUint(limitBytes*9/10, 10)+"\n"), 0o600); err != nil {
 		return fmt.Errorf("cgroup-memory: write memory.high: %w", err)
 	}
 
@@ -150,8 +152,8 @@ func (s CgroupMemoryScenario) Run(ctx context.Context, opts Options) error {
 			}
 
 			events := fmt.Sprintf("low 0\nhigh %d\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n", highEvents)
-			_ = os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte(strconv.FormatUint(current, 10)+"\n"), 0o644)
-			_ = os.WriteFile(filepath.Join(cgroupDir, "memory.events"), []byte(events), 0o644)
+			_ = os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte(strconv.FormatUint(current, 10)+"\n"), 0o600)
+			_ = os.WriteFile(filepath.Join(cgroupDir, "memory.events"), []byte(events), 0o600)
 		}
 	}
 }

--- a/internal/chaos/memory.go
+++ b/internal/chaos/memory.go
@@ -83,9 +83,9 @@ func memoryMBFromIntensity(intensity Intensity) int {
 
 // CgroupMemoryScenario creates a simulated cgroup v2 directory tree under
 // /tmp with memory.max set to a finite limit and memory.current growing
-// toward it. The kerno doctor CgroupMemoryCollector must be pointed at the
-// same root (via --cgroup-root or the KERNO_CGROUP_ROOT env var) to detect
-// the simulated pressure.
+// toward it. Set KERNO_CGROUP_ROOT to the printed path before running
+// kerno doctor so the CgroupMemoryCollector reads the simulated files
+// instead of /sys/fs/cgroup.
 //
 // This pairs with the memory_limit_pressure rule.
 type CgroupMemoryScenario struct{}
@@ -118,10 +118,10 @@ func (s CgroupMemoryScenario) Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("cgroup-memory: write memory.high: %w", err)
 	}
 
-	fmt.Fprintf(opts.Out, "    cgroup root: %s\n", filepath.Join(os.TempDir(), "kerno-chaos-cgroup"))
+	chaosRoot := filepath.Join(os.TempDir(), "kerno-chaos-cgroup")
+	fmt.Fprintf(opts.Out, "    cgroup root: %s\n", chaosRoot)
 	fmt.Fprintf(opts.Out, "    memory.max=%d MB, growing toward limit\n", limitMB)
-	fmt.Fprintf(opts.Out, "    hint: run kerno doctor --cgroup-root=%s to detect pressure\n",
-		filepath.Join(os.TempDir(), "kerno-chaos-cgroup"))
+	fmt.Fprintf(opts.Out, "    hint: export KERNO_CGROUP_ROOT=%s && kerno doctor\n", chaosRoot)
 
 	// Grow current usage from 80 % to 97 % over the run duration.
 	startBytes := limitBytes * 80 / 100
@@ -152,8 +152,12 @@ func (s CgroupMemoryScenario) Run(ctx context.Context, opts Options) error {
 			}
 
 			events := fmt.Sprintf("low 0\nhigh %d\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n", highEvents)
-			_ = os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte(strconv.FormatUint(current, 10)+"\n"), 0o600)
-			_ = os.WriteFile(filepath.Join(cgroupDir, "memory.events"), []byte(events), 0o600)
+			if err := os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte(strconv.FormatUint(current, 10)+"\n"), 0o600); err != nil {
+				opts.Logger.Warn("cgroup-memory: failed to update memory.current", "error", err)
+			}
+			if err := os.WriteFile(filepath.Join(cgroupDir, "memory.events"), []byte(events), 0o600); err != nil {
+				opts.Logger.Warn("cgroup-memory: failed to update memory.events", "error", err)
+			}
 		}
 	}
 }

--- a/internal/chaos/memory.go
+++ b/internal/chaos/memory.go
@@ -6,7 +6,10 @@ package chaos
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 )
 
@@ -73,5 +76,93 @@ func memoryMBFromIntensity(intensity Intensity) int {
 		return 512
 	default:
 		return 200
+	}
+}
+
+// ─── CgroupMemoryScenario ────────────────────────────────────────────────────
+
+// CgroupMemoryScenario creates a simulated cgroup v2 directory tree under
+// /tmp with memory.max set to a finite limit and memory.current growing
+// toward it. The kerno doctor CgroupMemoryCollector must be pointed at the
+// same root (via --cgroup-root or the KERNO_CGROUP_ROOT env var) to detect
+// the simulated pressure.
+//
+// This pairs with the memory_limit_pressure rule.
+type CgroupMemoryScenario struct{}
+
+func init() { Register(CgroupMemoryScenario{}) }
+
+func (CgroupMemoryScenario) Name() string        { return "cgroup-memory" }
+func (CgroupMemoryScenario) Description() string  { return "Simulate a container approaching its cgroup memory.max limit" }
+func (CgroupMemoryScenario) PairedRule() string   { return "memory_limit_pressure" }
+
+// Run implements Scenario.
+func (s CgroupMemoryScenario) Run(ctx context.Context, opts Options) error {
+	limitMB := cgroupMemoryLimitMB(opts.Intensity)
+	limitBytes := uint64(limitMB) << 20
+
+	cgroupDir := filepath.Join(os.TempDir(), "kerno-chaos-cgroup", "kubepods", "burstable", "pod-kerno-chaos", "container-0")
+	if err := os.MkdirAll(cgroupDir, 0o755); err != nil {
+		return fmt.Errorf("cgroup-memory: create dir: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(filepath.Join(os.TempDir(), "kerno-chaos-cgroup"))
+	}()
+
+	if err := os.WriteFile(filepath.Join(cgroupDir, "memory.max"), []byte(strconv.FormatUint(limitBytes, 10)+"\n"), 0o644); err != nil {
+		return fmt.Errorf("cgroup-memory: write memory.max: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(cgroupDir, "memory.high"), []byte(strconv.FormatUint(limitBytes*9/10, 10)+"\n"), 0o644); err != nil {
+		return fmt.Errorf("cgroup-memory: write memory.high: %w", err)
+	}
+
+	fmt.Fprintf(opts.Out, "    cgroup root: %s\n", filepath.Join(os.TempDir(), "kerno-chaos-cgroup"))
+	fmt.Fprintf(opts.Out, "    memory.max=%d MB, growing toward limit\n", limitMB)
+	fmt.Fprintf(opts.Out, "    hint: run kerno doctor --cgroup-root=%s to detect pressure\n",
+		filepath.Join(os.TempDir(), "kerno-chaos-cgroup"))
+
+	// Grow current usage from 80 % to 97 % over the run duration.
+	startBytes := limitBytes * 80 / 100
+	endBytes := limitBytes * 97 / 100
+	rangeBytes := endBytes - startBytes
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	start := time.Now()
+	highEvents := uint64(0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			elapsed := time.Since(start)
+			frac := elapsed.Seconds() / opts.Duration.Seconds()
+			if frac > 1.0 {
+				frac = 1.0
+			}
+			current := startBytes + uint64(float64(rangeBytes)*frac)
+
+			// Increment high events to simulate kernel reclaim pressure.
+			if current >= limitBytes*85/100 {
+				highEvents += 2
+			}
+
+			events := fmt.Sprintf("low 0\nhigh %d\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n", highEvents)
+			_ = os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte(strconv.FormatUint(current, 10)+"\n"), 0o644)
+			_ = os.WriteFile(filepath.Join(cgroupDir, "memory.events"), []byte(events), 0o644)
+		}
+	}
+}
+
+func cgroupMemoryLimitMB(intensity Intensity) int {
+	switch intensity {
+	case IntensityLow:
+		return 128
+	case IntensityHigh:
+		return 1024
+	default:
+		return 256
 	}
 }

--- a/internal/chaos/paired_rule_test.go
+++ b/internal/chaos/paired_rule_test.go
@@ -10,19 +10,19 @@ import "testing"
 // here to keep chaos a leaf — so this list must stay in sync with
 // rules.go. The test below enforces the invariant.
 var validDoctorRules = map[string]bool{
-	"disk_io_bottleneck":   true,
-	"disk_io_write_high":   true,
-	"oom_kill_occurred":    true,
-	"oom_imminent":         true,
-	"tcp_retransmit_storm": true,
-	"tcp_rtt_degradation":  true,
-	"scheduler_contention": true,
-	"fd_leak":              true,
-	"syscall_latency_high":    true,
-	"syscall_error_rate":      true,
-	"memory_limit_pressure":   true,
-	"memory_high_throttling":  true,
-	"healthy_system":          true,
+	"disk_io_bottleneck":     true,
+	"disk_io_write_high":     true,
+	"oom_kill_occurred":      true,
+	"oom_imminent":           true,
+	"tcp_retransmit_storm":   true,
+	"tcp_rtt_degradation":    true,
+	"scheduler_contention":   true,
+	"fd_leak":                true,
+	"syscall_latency_high":   true,
+	"syscall_error_rate":     true,
+	"memory_limit_pressure":  true,
+	"memory_high_throttling": true,
+	"healthy_system":         true,
 	// "multiple" is a sentinel used by cascade — not a real rule but a
 	// recognized placeholder.
 	"multiple": true,

--- a/internal/chaos/paired_rule_test.go
+++ b/internal/chaos/paired_rule_test.go
@@ -18,9 +18,11 @@ var validDoctorRules = map[string]bool{
 	"tcp_rtt_degradation":  true,
 	"scheduler_contention": true,
 	"fd_leak":              true,
-	"syscall_latency_high": true,
-	"syscall_error_rate":   true,
-	"healthy_system":       true,
+	"syscall_latency_high":    true,
+	"syscall_error_rate":      true,
+	"memory_limit_pressure":   true,
+	"memory_high_throttling":  true,
+	"healthy_system":          true,
 	// "multiple" is a sentinel used by cascade — not a real rule but a
 	// recognized placeholder.
 	"multiple": true,

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -205,8 +205,8 @@ type collectorBuildResult struct {
 // DEGRADATION panel instead of letting WARN logs scatter through.
 func buildCollectors(logger *slog.Logger) collectorBuildResult {
 	registry := collector.NewRegistry(logger)
-	// Up to 7 collectors are registered (6 eBPF + procfs memory).
-	closers := make([]func(), 0, 7)
+	// Up to 8 collectors are registered (6 eBPF + procfs memory + cgroup memory).
+	closers := make([]func(), 0, 8)
 
 	type loaderRegistration struct {
 		name    string
@@ -298,6 +298,15 @@ func buildCollectors(logger *slog.Logger) collectorBuildResult {
 			enabled: true,
 			build: func() (collector.Collector, io.Closer, error) {
 				return collector.NewMemoryCollector(logger, 0), noopCloser{}, nil
+			},
+		},
+		{
+			// Cgroup memory collector walks /sys/fs/cgroup for per-container
+			// limits. Also no eBPF; root overrideable via KERNO_CGROUP_ROOT.
+			name:    "cgroup_memory",
+			enabled: true,
+			build: func() (collector.Collector, io.Closer, error) {
+				return collector.NewCgroupMemoryCollector(logger, 0), noopCloser{}, nil
 			},
 		},
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -153,7 +153,7 @@ func runDoctor(ctx context.Context, opts doctorOpts) error {
 	// Build the eBPF loader set + collector registry. Loader failures are
 	// non-fatal — we degrade gracefully and surface the gap in the report
 	// via a single DEGRADATION panel.
-	build := buildCollectors(logger)
+	build := buildCollectors(ctx, logger)
 	defer func() {
 		for _, c := range build.closers {
 			c()
@@ -203,7 +203,7 @@ type collectorBuildResult struct {
 // skipped (graceful degradation) but their errors are captured into
 // the result so the doctor's pretty renderer can show a single
 // DEGRADATION panel instead of letting WARN logs scatter through.
-func buildCollectors(logger *slog.Logger) collectorBuildResult {
+func buildCollectors(ctx context.Context, logger *slog.Logger) collectorBuildResult {
 	registry := collector.NewRegistry(logger)
 	// Up to 8 collectors are registered (6 eBPF + procfs memory + cgroup memory).
 	closers := make([]func(), 0, 8)
@@ -216,6 +216,9 @@ func buildCollectors(logger *slog.Logger) collectorBuildResult {
 		// (nil, nil, error) so the caller can log + skip.
 		build func() (collector.Collector, io.Closer, error)
 	}
+
+	// Captured so we can inject a pod enricher after the registration loop.
+	var cgroupColl *collector.CgroupMemoryCollector
 
 	registrations := []loaderRegistration{
 		{
@@ -306,7 +309,8 @@ func buildCollectors(logger *slog.Logger) collectorBuildResult {
 			name:    "cgroup_memory",
 			enabled: true,
 			build: func() (collector.Collector, io.Closer, error) {
-				return collector.NewCgroupMemoryCollector(logger, 0), noopCloser{}, nil
+				cgroupColl = collector.NewCgroupMemoryCollector(logger, 0)
+				return cgroupColl, noopCloser{}, nil
 			},
 		},
 	}
@@ -343,6 +347,19 @@ func buildCollectors(logger *slog.Logger) collectorBuildResult {
 			continue
 		}
 		loaded++
+	}
+
+	// Wire Kubernetes pod/namespace enrichment into the cgroup collector.
+	// The adapter queries the local Kubelet API; on non-K8s nodes its index
+	// stays empty and LookupByPath returns ("", "") — a no-op.
+	if cgroupColl != nil {
+		kubeAdapter := adapter.NewKubernetesAdapter(logger)
+		// Start in a goroutine so a slow or absent Kubelet does not block
+		// the doctor startup. Enrichment is best-effort: early polls may
+		// have empty namespace; later polls will have it once the index is built.
+		go func() { _ = kubeAdapter.Start(ctx) }() //nolint:errcheck // Start always returns nil
+		cgroupColl.SetEnricher(kubeAdapter)
+		closers = append(closers, func() { kubeAdapter.Stop() })
 	}
 
 	return collectorBuildResult{

--- a/internal/collector/cgroup_memory.go
+++ b/internal/collector/cgroup_memory.go
@@ -43,6 +43,8 @@ type CgroupMemoryCollector struct {
 	logger     *slog.Logger
 	interval   time.Duration
 	cgroupRoot string // overrideable for tests
+
+	enricherMu sync.RWMutex
 	enricher   PodLookup
 
 	mu   sync.Mutex
@@ -54,8 +56,12 @@ type CgroupMemoryCollector struct {
 }
 
 // SetEnricher injects an optional pod lookup for namespace enrichment.
-// Safe to call before Start(); not safe to call concurrently.
-func (c *CgroupMemoryCollector) SetEnricher(e PodLookup) { c.enricher = e }
+// Safe to call at any time, including after Start().
+func (c *CgroupMemoryCollector) SetEnricher(e PodLookup) {
+	c.enricherMu.Lock()
+	c.enricher = e
+	c.enricherMu.Unlock()
+}
 
 type cgroupMemSample struct {
 	currentBytes uint64
@@ -239,10 +245,12 @@ func (c *CgroupMemoryCollector) walkCgroups(dir string, depth int) ([]CgroupMemo
 
 		pod := parseCgroupPod(dir)
 		ns := ""
-		if c.enricher != nil {
-			pod, ns = c.enricher.LookupByPath(dir)
-			if pod == "" {
-				pod = parseCgroupPod(dir)
+		c.enricherMu.RLock()
+		enr := c.enricher
+		c.enricherMu.RUnlock()
+		if enr != nil {
+			if p, n := enr.LookupByPath(dir); p != "" {
+				pod, ns = p, n
 			}
 		}
 

--- a/internal/collector/cgroup_memory.go
+++ b/internal/collector/cgroup_memory.go
@@ -26,6 +26,13 @@ const DefaultCgroupMemoryPollInterval = 5 * time.Second
 // maxCgroupWalkDepth guards against unexpectedly deep cgroup trees.
 const maxCgroupWalkDepth = 8
 
+// PodLookup resolves a cgroup path to a Kubernetes pod name and namespace.
+// The KubernetesAdapter implements this interface; on non-K8s nodes the
+// injected value is nil and enrichment is skipped.
+type PodLookup interface {
+	LookupByPath(cgroupPath string) (pod, namespace string)
+}
+
 // CgroupMemoryCollector walks the cgroup v2 hierarchy and collects per-
 // container memory state every poll interval. It feeds the doctor's
 // memory_limit_pressure and memory_high_throttling rules.
@@ -36,6 +43,7 @@ type CgroupMemoryCollector struct {
 	logger     *slog.Logger
 	interval   time.Duration
 	cgroupRoot string // overrideable for tests
+	enricher   PodLookup
 
 	mu   sync.Mutex
 	snap *CgroupMemorySnapshot
@@ -44,6 +52,10 @@ type CgroupMemoryCollector struct {
 	cancelFn context.CancelFunc
 	done     chan struct{}
 }
+
+// SetEnricher injects an optional pod lookup for namespace enrichment.
+// Safe to call before Start(); not safe to call concurrently.
+func (c *CgroupMemoryCollector) SetEnricher(e PodLookup) { c.enricher = e }
 
 type cgroupMemSample struct {
 	currentBytes uint64
@@ -159,7 +171,7 @@ func (c *CgroupMemoryCollector) poll() error {
 	// combinations that no longer exist.
 	metrics.CgroupMemoryPressurePct.Reset()
 	for _, e := range entries {
-		metrics.CgroupMemoryPressurePct.WithLabelValues(e.Pod, e.Namespace).Set(e.UsedPct)
+		metrics.CgroupMemoryPressurePct.WithLabelValues(e.Pod).Set(e.UsedPct)
 	}
 
 	return nil
@@ -178,6 +190,10 @@ func (c *CgroupMemoryCollector) Snapshot() interface{} {
 
 // walkCgroups recursively visits cgroup directories and collects entries
 // that have a finite memory.max limit (i.e., the value is not "max").
+// Only leaf nodes in the limit hierarchy are emitted: if a child directory
+// also has memory.max set, the parent is skipped. This avoids 4–6 duplicate
+// findings per K8s pod where every level of the hierarchy (kubepods.slice →
+// pod.slice → container.scope) has memory.max set.
 func (c *CgroupMemoryCollector) walkCgroups(dir string, depth int) ([]CgroupMemoryEntry, error) {
 	if depth > maxCgroupWalkDepth {
 		return nil, nil
@@ -191,35 +207,11 @@ func (c *CgroupMemoryCollector) walkCgroups(dir string, depth int) ([]CgroupMemo
 		return nil, err
 	}
 
-	var result []CgroupMemoryEntry
-
 	limitBytes, hasLimit := readCgroupMemoryMax(filepath.Join(dir, "memory.max"))
-	if hasLimit {
-		current := readCgroupUint64File(filepath.Join(dir, "memory.current"))
-		highBytes := readCgroupUint64File(filepath.Join(dir, "memory.high"))
-		events := readCgroupMemoryEvents(filepath.Join(dir, "memory.events"))
 
-		usedPct := 0.0
-		if limitBytes > 0 {
-			usedPct = float64(current) / float64(limitBytes) * 100.0
-		}
-
-		pod := parseCgroupPod(dir)
-		result = append(result, CgroupMemoryEntry{
-			CgroupPath:    dir,
-			Pod:           pod,
-			Namespace:     "",
-			CurrentBytes:  current,
-			LimitBytes:    limitBytes,
-			HighBytes:     highBytes,
-			UsedPct:       usedPct,
-			EventsHigh:    events["high"],
-			EventsMax:     events["max"],
-			EventsOOM:     events["oom"],
-			EventsOOMKill: events["oom_kill"],
-		})
-	}
-
+	// Recurse into children first so we can tell whether any child also has
+	// a finite limit. If so, this node is an intermediate parent — skip it.
+	var result []CgroupMemoryEntry
 	for _, de := range dirEntries {
 		if !de.IsDir() {
 			continue
@@ -231,6 +223,42 @@ func (c *CgroupMemoryCollector) walkCgroups(dir string, depth int) ([]CgroupMemo
 			continue
 		}
 		result = append(result, children...)
+	}
+
+	// Emit this node only if it has a finite limit AND no child also reported
+	// an entry (i.e., this is the innermost / leaf cgroup with a limit).
+	if hasLimit && len(result) == 0 {
+		current := readCgroupUint64File(filepath.Join(dir, "memory.current"))
+		highBytes := readCgroupUint64File(filepath.Join(dir, "memory.high"))
+		events := readCgroupMemoryEvents(filepath.Join(dir, "memory.events"))
+
+		usedPct := 0.0
+		if limitBytes > 0 {
+			usedPct = float64(current) / float64(limitBytes) * 100.0
+		}
+
+		pod := parseCgroupPod(dir)
+		ns := ""
+		if c.enricher != nil {
+			pod, ns = c.enricher.LookupByPath(dir)
+			if pod == "" {
+				pod = parseCgroupPod(dir)
+			}
+		}
+
+		result = append(result, CgroupMemoryEntry{
+			CgroupPath:    dir,
+			Pod:           pod,
+			Namespace:     ns,
+			CurrentBytes:  current,
+			LimitBytes:    limitBytes,
+			HighBytes:     highBytes,
+			UsedPct:       usedPct,
+			EventsHigh:    events["high"],
+			EventsMax:     events["max"],
+			EventsOOM:     events["oom"],
+			EventsOOMKill: events["oom_kill"],
+		})
 	}
 
 	return result, nil

--- a/internal/collector/cgroup_memory.go
+++ b/internal/collector/cgroup_memory.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/optiqor/kerno/internal/metrics"
 )
 
 // DefaultCgroupMemoryPollInterval is the polling cadence for cgroup memory
@@ -51,14 +53,21 @@ type cgroupMemSample struct {
 
 // NewCgroupMemoryCollector creates a collector that reads
 // /sys/fs/cgroup (or cgroupRoot if overridden) every interval.
+// The root can also be overridden at runtime via the KERNO_CGROUP_ROOT
+// environment variable, which is how the cgroup-memory chaos scenario
+// surfaces simulated pressure to the collector.
 func NewCgroupMemoryCollector(logger *slog.Logger, interval time.Duration) *CgroupMemoryCollector {
 	if interval <= 0 {
 		interval = DefaultCgroupMemoryPollInterval
 	}
+	root := "/sys/fs/cgroup"
+	if env := os.Getenv("KERNO_CGROUP_ROOT"); env != "" {
+		root = env
+	}
 	return &CgroupMemoryCollector{
 		logger:     logger.With("collector", "cgroup_memory"),
 		interval:   interval,
-		cgroupRoot: "/sys/fs/cgroup",
+		cgroupRoot: root,
 		prev:       make(map[string]cgroupMemSample),
 		done:       make(chan struct{}),
 	}
@@ -136,9 +145,23 @@ func (c *CgroupMemoryCollector) poll() error {
 		}
 	}
 
-	if len(entries) > 0 {
-		c.snap = &CgroupMemorySnapshot{Containers: entries}
+	// Always overwrite the snapshot — nil when no limited cgroups are
+	// present so stale findings don't linger after limits are removed.
+	if len(entries) == 0 {
+		c.snap = nil
+		metrics.CgroupMemoryPressurePct.Reset()
+		return nil
 	}
+
+	c.snap = &CgroupMemorySnapshot{Containers: entries}
+
+	// Update the Prometheus gauge for each container and clear any label
+	// combinations that no longer exist.
+	metrics.CgroupMemoryPressurePct.Reset()
+	for _, e := range entries {
+		metrics.CgroupMemoryPressurePct.WithLabelValues(e.Pod, e.Namespace).Set(e.UsedPct)
+	}
+
 	return nil
 }
 

--- a/internal/collector/cgroup_memory.go
+++ b/internal/collector/cgroup_memory.go
@@ -181,11 +181,11 @@ func (c *CgroupMemoryCollector) walkCgroups(dir string, depth int) ([]CgroupMemo
 			usedPct = float64(current) / float64(limitBytes) * 100.0
 		}
 
-		pod, ns := parseCgroupPodNamespace(dir)
+		pod := parseCgroupPod(dir)
 		result = append(result, CgroupMemoryEntry{
 			CgroupPath:    dir,
 			Pod:           pod,
-			Namespace:     ns,
+			Namespace:     "",
 			CurrentBytes:  current,
 			LimitBytes:    limitBytes,
 			HighBytes:     highBytes,
@@ -216,7 +216,7 @@ func (c *CgroupMemoryCollector) walkCgroups(dir string, depth int) ([]CgroupMemo
 // readCgroupMemoryMax reads memory.max. Returns (bytes, true) when a finite
 // limit is set; (0, false) for "max" (unlimited) or missing file.
 func readCgroupMemoryMax(path string) (uint64, bool) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path is constructed from the controlled cgroupRoot
 	if err != nil {
 		return 0, false
 	}
@@ -234,7 +234,7 @@ func readCgroupMemoryMax(path string) (uint64, bool) {
 // readCgroupUint64File reads a single uint64 from a cgroup file, returning 0
 // on error or when the value is the sentinel "max".
 func readCgroupUint64File(path string) uint64 {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path is constructed from the controlled cgroupRoot
 	if err != nil {
 		return 0
 	}
@@ -260,7 +260,7 @@ func readCgroupUint64File(path string) uint64 {
 //	oom_group_kill 0
 func readCgroupMemoryEvents(path string) map[string]uint64 {
 	out := make(map[string]uint64)
-	f, err := os.Open(path)
+	f, err := os.Open(path) //nolint:gosec // path is constructed from the controlled cgroupRoot
 	if err != nil {
 		return out
 	}
@@ -280,26 +280,25 @@ func readCgroupMemoryEvents(path string) map[string]uint64 {
 	return out
 }
 
-// parseCgroupPodNamespace extracts a pod identifier and namespace from a
-// cgroup path. Kubernetes uses paths like:
+// parseCgroupPod extracts a pod identifier from a cgroup path.
+// Kubernetes uses paths like:
 //
 //	/sys/fs/cgroup/kubepods/burstable/pod<uid>/<container-id>
 //
-// We return the pod<uid> component as pod and leave namespace empty —
-// full namespace resolution requires the Kubernetes API.
-func parseCgroupPodNamespace(path string) (pod, namespace string) {
+// Namespace resolution requires the Kubernetes API and is not done here;
+// callers set Namespace="" and enrich later if needed.
+func parseCgroupPod(path string) string {
 	parts := strings.Split(filepath.ToSlash(path), "/")
 	for _, p := range parts {
 		if strings.HasPrefix(p, "pod") && len(p) > 3 {
-			return p, ""
+			return p
 		}
 	}
-	// Not a K8s-style path — use the last component as an identifier.
-	if len(parts) > 0 {
-		last := parts[len(parts)-1]
-		if last != "" {
-			return last, ""
+	// Not a K8s-style path — use the last non-empty component.
+	for i := len(parts) - 1; i >= 0; i-- {
+		if parts[i] != "" {
+			return parts[i]
 		}
 	}
-	return filepath.Base(path), ""
+	return filepath.Base(path)
 }

--- a/internal/collector/cgroup_memory.go
+++ b/internal/collector/cgroup_memory.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultCgroupMemoryPollInterval is the polling cadence for cgroup memory
+// files. 5s is enough resolution for OOMKill prediction while keeping
+// /sys/fs/cgroup read overhead negligible.
+const DefaultCgroupMemoryPollInterval = 5 * time.Second
+
+// maxCgroupWalkDepth guards against unexpectedly deep cgroup trees.
+const maxCgroupWalkDepth = 8
+
+// CgroupMemoryCollector walks the cgroup v2 hierarchy and collects per-
+// container memory state every poll interval. It feeds the doctor's
+// memory_limit_pressure and memory_high_throttling rules.
+//
+// On bare metal without cgroup memory limits, Snapshot() returns nil —
+// the rules gracefully handle the nil case.
+type CgroupMemoryCollector struct {
+	logger     *slog.Logger
+	interval   time.Duration
+	cgroupRoot string // overrideable for tests
+
+	mu   sync.Mutex
+	snap *CgroupMemorySnapshot
+	prev map[string]cgroupMemSample
+
+	cancelFn context.CancelFunc
+	done     chan struct{}
+}
+
+type cgroupMemSample struct {
+	currentBytes uint64
+	eventsHigh   uint64
+	at           time.Time
+}
+
+// NewCgroupMemoryCollector creates a collector that reads
+// /sys/fs/cgroup (or cgroupRoot if overridden) every interval.
+func NewCgroupMemoryCollector(logger *slog.Logger, interval time.Duration) *CgroupMemoryCollector {
+	if interval <= 0 {
+		interval = DefaultCgroupMemoryPollInterval
+	}
+	return &CgroupMemoryCollector{
+		logger:     logger.With("collector", "cgroup_memory"),
+		interval:   interval,
+		cgroupRoot: "/sys/fs/cgroup",
+		prev:       make(map[string]cgroupMemSample),
+		done:       make(chan struct{}),
+	}
+}
+
+// Name implements Collector.
+func (c *CgroupMemoryCollector) Name() string { return "cgroup_memory" }
+
+// Start implements Collector.
+func (c *CgroupMemoryCollector) Start(ctx context.Context) error {
+	runCtx, cancel := context.WithCancel(ctx)
+	c.cancelFn = cancel
+	if err := c.poll(); err != nil {
+		c.logger.Debug("initial cgroup memory poll failed", "error", err)
+	}
+	go c.loop(runCtx)
+	return nil
+}
+
+// Stop implements Collector.
+func (c *CgroupMemoryCollector) Stop() {
+	if c.cancelFn != nil {
+		c.cancelFn()
+	}
+	select {
+	case <-c.done:
+	case <-time.After(2 * time.Second):
+		c.logger.Warn("cgroup memory collector did not stop within timeout")
+	}
+}
+
+func (c *CgroupMemoryCollector) loop(ctx context.Context) {
+	defer close(c.done)
+	t := time.NewTicker(c.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := c.poll(); err != nil {
+				c.logger.Debug("cgroup memory poll failed", "error", err)
+			}
+		}
+	}
+}
+
+func (c *CgroupMemoryCollector) poll() error {
+	entries, err := c.walkCgroups(c.cgroupRoot, 0)
+	if err != nil {
+		return fmt.Errorf("cgroup walk: %w", err)
+	}
+
+	now := time.Now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for i := range entries {
+		prev, ok := c.prev[entries[i].CgroupPath]
+		if ok {
+			dt := now.Sub(prev.at).Seconds()
+			if dt > 0 {
+				entries[i].GrowthRateBytesPerSec = float64(int64(entries[i].CurrentBytes)-int64(prev.currentBytes)) / dt
+				rate := float64(int64(entries[i].EventsHigh)-int64(prev.eventsHigh)) / dt
+				if rate > 0 {
+					entries[i].HighEventRate = rate
+				}
+			}
+		}
+		c.prev[entries[i].CgroupPath] = cgroupMemSample{
+			currentBytes: entries[i].CurrentBytes,
+			eventsHigh:   entries[i].EventsHigh,
+			at:           now,
+		}
+	}
+
+	if len(entries) > 0 {
+		c.snap = &CgroupMemorySnapshot{Containers: entries}
+	}
+	return nil
+}
+
+// Snapshot implements Collector. Returns *CgroupMemorySnapshot or nil.
+func (c *CgroupMemoryCollector) Snapshot() interface{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.snap == nil {
+		return nil
+	}
+	out := *c.snap
+	return &out
+}
+
+// walkCgroups recursively visits cgroup directories and collects entries
+// that have a finite memory.max limit (i.e., the value is not "max").
+func (c *CgroupMemoryCollector) walkCgroups(dir string, depth int) ([]CgroupMemoryEntry, error) {
+	if depth > maxCgroupWalkDepth {
+		return nil, nil
+	}
+
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var result []CgroupMemoryEntry
+
+	limitBytes, hasLimit := readCgroupMemoryMax(filepath.Join(dir, "memory.max"))
+	if hasLimit {
+		current := readCgroupUint64File(filepath.Join(dir, "memory.current"))
+		highBytes := readCgroupUint64File(filepath.Join(dir, "memory.high"))
+		events := readCgroupMemoryEvents(filepath.Join(dir, "memory.events"))
+
+		usedPct := 0.0
+		if limitBytes > 0 {
+			usedPct = float64(current) / float64(limitBytes) * 100.0
+		}
+
+		pod, ns := parseCgroupPodNamespace(dir)
+		result = append(result, CgroupMemoryEntry{
+			CgroupPath:    dir,
+			Pod:           pod,
+			Namespace:     ns,
+			CurrentBytes:  current,
+			LimitBytes:    limitBytes,
+			HighBytes:     highBytes,
+			UsedPct:       usedPct,
+			EventsHigh:    events["high"],
+			EventsMax:     events["max"],
+			EventsOOM:     events["oom"],
+			EventsOOMKill: events["oom_kill"],
+		})
+	}
+
+	for _, de := range dirEntries {
+		if !de.IsDir() {
+			continue
+		}
+		sub := filepath.Join(dir, de.Name())
+		children, err := c.walkCgroups(sub, depth+1)
+		if err != nil {
+			c.logger.Debug("cgroup walk error", "path", sub, "error", err)
+			continue
+		}
+		result = append(result, children...)
+	}
+
+	return result, nil
+}
+
+// readCgroupMemoryMax reads memory.max. Returns (bytes, true) when a finite
+// limit is set; (0, false) for "max" (unlimited) or missing file.
+func readCgroupMemoryMax(path string) (uint64, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "max" || s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// readCgroupUint64File reads a single uint64 from a cgroup file, returning 0
+// on error or when the value is the sentinel "max".
+func readCgroupUint64File(path string) uint64 {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "max" {
+		return 0
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// readCgroupMemoryEvents parses the key-value pairs in memory.events.
+// Example file:
+//
+//	low 0
+//	high 4
+//	max 2
+//	oom 1
+//	oom_kill 1
+//	oom_group_kill 0
+func readCgroupMemoryEvents(path string) map[string]uint64 {
+	out := make(map[string]uint64)
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) != 2 {
+			continue
+		}
+		v, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		out[parts[0]] = v
+	}
+	return out
+}
+
+// parseCgroupPodNamespace extracts a pod identifier and namespace from a
+// cgroup path. Kubernetes uses paths like:
+//
+//	/sys/fs/cgroup/kubepods/burstable/pod<uid>/<container-id>
+//
+// We return the pod<uid> component as pod and leave namespace empty —
+// full namespace resolution requires the Kubernetes API.
+func parseCgroupPodNamespace(path string) (pod, namespace string) {
+	parts := strings.Split(filepath.ToSlash(path), "/")
+	for _, p := range parts {
+		if strings.HasPrefix(p, "pod") && len(p) > 3 {
+			return p, ""
+		}
+	}
+	// Not a K8s-style path — use the last component as an identifier.
+	if len(parts) > 0 {
+		last := parts[len(parts)-1]
+		if last != "" {
+			return last, ""
+		}
+	}
+	return filepath.Base(path), ""
+}

--- a/internal/collector/cgroup_memory_test.go
+++ b/internal/collector/cgroup_memory_test.go
@@ -194,6 +194,56 @@ func TestCgroupMemoryCollector_StartStop(t *testing.T) {
 	}
 }
 
+// TestCgroupMemoryCollector_LeafOnly verifies that when a parent directory
+// and a child directory both have a finite memory.max, only the child (leaf)
+// is reported. This mirrors the real K8s hierarchy where kubepods.slice,
+// pod.slice, and container.scope all have memory.max set.
+func TestCgroupMemoryCollector_LeafOnly(t *testing.T) {
+	root := t.TempDir()
+
+	// Parent cgroup with a limit — should NOT be reported because its child
+	// also has a limit.
+	parentDir := filepath.Join(root, "kubepods", "burstable", "pod-test")
+	if err := os.MkdirAll(parentDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeFileAt := func(path, content string) {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	const limitBytes = uint64(512 << 20)
+	writeFileAt(filepath.Join(parentDir, "memory.max"), fmt.Sprintf("%d\n", limitBytes))
+	writeFileAt(filepath.Join(parentDir, "memory.current"), fmt.Sprintf("%d\n", limitBytes/2))
+	writeFileAt(filepath.Join(parentDir, "memory.high"), fmt.Sprintf("%d\n", limitBytes*9/10))
+	writeFileAt(filepath.Join(parentDir, "memory.events"), "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n")
+
+	// Child (leaf) cgroup — the one that should be reported.
+	childDir := filepath.Join(parentDir, "container-0")
+	writeCgroupDir(t, filepath.Join(root, "kubepods", "burstable", "pod-test"), limitBytes, limitBytes*3/4, limitBytes*9/10, 0)
+	// writeCgroupDir creates container-0 under pod-test automatically.
+	_ = childDir
+
+	c := NewCgroupMemoryCollector(newSilentLogger(), 50*time.Millisecond)
+	c.cgroupRoot = root
+
+	if err := c.poll(); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	snap, ok := c.Snapshot().(*CgroupMemorySnapshot)
+	if !ok || snap == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if len(snap.Containers) != 1 {
+		t.Fatalf("leaf-only: expected 1 container, got %d (duplicate parent entries)", len(snap.Containers))
+	}
+	// The reported entry must be the leaf (container-0), not the parent.
+	if snap.Containers[0].CgroupPath == parentDir {
+		t.Errorf("reported parent %q instead of leaf container", parentDir)
+	}
+}
+
 func TestReadCgroupMemoryEvents(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "memory.events")

--- a/internal/collector/cgroup_memory_test.go
+++ b/internal/collector/cgroup_memory_test.go
@@ -1,0 +1,235 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeCgroupDir creates a simulated cgroup v2 directory tree under dir.
+func writeCgroupDir(t *testing.T, root string, limitBytes, currentBytes, highBytes uint64, eventsHigh uint64) string {
+	t.Helper()
+	cgroupPath := filepath.Join(root, "kubepods", "burstable", "pod-test", "container-0")
+	if err := os.MkdirAll(cgroupPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(cgroupPath, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile("memory.max", fmt.Sprintf("%d\n", limitBytes))
+	writeFile("memory.current", fmt.Sprintf("%d\n", currentBytes))
+	writeFile("memory.high", fmt.Sprintf("%d\n", highBytes))
+	writeFile("memory.events", fmt.Sprintf("low 0\nhigh %d\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n", eventsHigh))
+	return cgroupPath
+}
+
+func TestCgroupMemoryCollector_BasicPoll(t *testing.T) {
+	root := t.TempDir()
+	const limitBytes = 4 << 30  // 4 GiB
+	const currentBytes = 3 << 30 // 3 GiB = 75%
+	writeCgroupDir(t, root, limitBytes, currentBytes, limitBytes*9/10, 0)
+
+	c := NewCgroupMemoryCollector(newSilentLogger(), 50*time.Millisecond)
+	c.cgroupRoot = root
+
+	if err := c.poll(); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	snap, ok := c.Snapshot().(*CgroupMemorySnapshot)
+	if !ok || snap == nil {
+		t.Fatal("expected non-nil CgroupMemorySnapshot")
+	}
+	if len(snap.Containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(snap.Containers))
+	}
+	e := snap.Containers[0]
+	if e.LimitBytes != limitBytes {
+		t.Errorf("LimitBytes = %d, want %d", e.LimitBytes, uint64(limitBytes))
+	}
+	if e.CurrentBytes != currentBytes {
+		t.Errorf("CurrentBytes = %d, want %d", e.CurrentBytes, uint64(currentBytes))
+	}
+	if e.UsedPct < 74.0 || e.UsedPct > 76.0 {
+		t.Errorf("UsedPct = %.1f, want ~75", e.UsedPct)
+	}
+	if e.Pod == "" {
+		t.Error("Pod should be non-empty (extracted from path)")
+	}
+}
+
+func TestCgroupMemoryCollector_UnlimitedMax(t *testing.T) {
+	root := t.TempDir()
+	cgroupPath := filepath.Join(root, "container-unlimited")
+	if err := os.MkdirAll(cgroupPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// memory.max = "max" means unlimited — should be ignored.
+	if err := os.WriteFile(filepath.Join(cgroupPath, "memory.max"), []byte("max\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cgroupPath, "memory.current"), []byte("1073741824\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCgroupMemoryCollector(newSilentLogger(), 50*time.Millisecond)
+	c.cgroupRoot = root
+
+	if err := c.poll(); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	if snap := c.Snapshot(); snap != nil {
+		s := snap.(*CgroupMemorySnapshot)
+		for _, e := range s.Containers {
+			if e.LimitBytes == 0 {
+				t.Error("container with memory.max=max should not appear in snapshot")
+			}
+		}
+	}
+}
+
+func TestCgroupMemoryCollector_GrowthRate(t *testing.T) {
+	root := t.TempDir()
+	const limitBytes = 1 << 30 // 1 GiB
+	cgPath := writeCgroupDir(t, root, limitBytes, 700<<20, limitBytes*9/10, 0) // 700 MB initial
+
+	c := NewCgroupMemoryCollector(newSilentLogger(), 10*time.Millisecond)
+	c.cgroupRoot = root
+
+	if err := c.poll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate memory growth to 800 MB.
+	time.Sleep(50 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(cgPath, "memory.current"), []byte(fmt.Sprintf("%d\n", 800<<20)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.poll(); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := c.Snapshot().(*CgroupMemorySnapshot)
+	if len(snap.Containers) == 0 {
+		t.Fatal("expected containers in snapshot")
+	}
+	if snap.Containers[0].GrowthRateBytesPerSec <= 0 {
+		t.Errorf("GrowthRateBytesPerSec = %v, want > 0", snap.Containers[0].GrowthRateBytesPerSec)
+	}
+}
+
+func TestCgroupMemoryCollector_HighEventRate(t *testing.T) {
+	root := t.TempDir()
+	const limitBytes = 1 << 30
+	cgPath := writeCgroupDir(t, root, limitBytes, 900<<20, limitBytes*9/10, 5)
+
+	c := NewCgroupMemoryCollector(newSilentLogger(), 10*time.Millisecond)
+	c.cgroupRoot = root
+
+	if err := c.poll(); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	// Increment high event counter by 10.
+	events := "low 0\nhigh 15\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n"
+	if err := os.WriteFile(filepath.Join(cgPath, "memory.events"), []byte(events), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.poll(); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := c.Snapshot().(*CgroupMemorySnapshot)
+	if len(snap.Containers) == 0 {
+		t.Fatal("expected containers in snapshot")
+	}
+	if snap.Containers[0].HighEventRate <= 0 {
+		t.Errorf("HighEventRate = %v, want > 0", snap.Containers[0].HighEventRate)
+	}
+}
+
+func TestCgroupMemoryCollector_EmptyRoot(t *testing.T) {
+	root := t.TempDir() // empty — no cgroup files
+
+	c := NewCgroupMemoryCollector(newSilentLogger(), 50*time.Millisecond)
+	c.cgroupRoot = root
+
+	if err := c.poll(); err != nil {
+		t.Fatalf("poll on empty root should not error: %v", err)
+	}
+	if snap := c.Snapshot(); snap != nil {
+		t.Error("expected nil snapshot for empty cgroup root")
+	}
+}
+
+func TestCgroupMemoryCollector_StartStop(t *testing.T) {
+	root := t.TempDir()
+	writeCgroupDir(t, root, 2<<30, 1<<30, 0, 0)
+
+	c := NewCgroupMemoryCollector(newSilentLogger(), 20*time.Millisecond)
+	c.cgroupRoot = root
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := c.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+	c.Stop()
+
+	if c.Snapshot() == nil {
+		t.Error("expected non-nil snapshot after Start+polls")
+	}
+}
+
+func TestReadCgroupMemoryEvents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "memory.events")
+	content := "low 0\nhigh 4\nmax 2\noom 1\noom_kill 1\noom_group_kill 0\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readCgroupMemoryEvents(path)
+	cases := map[string]uint64{"low": 0, "high": 4, "max": 2, "oom": 1, "oom_kill": 1, "oom_group_kill": 0}
+	for k, want := range cases {
+		if got[k] != want {
+			t.Errorf("events[%q] = %d, want %d", k, got[k], want)
+		}
+	}
+}
+
+func TestParseCgroupPodNamespace(t *testing.T) {
+	cases := []struct {
+		path      string
+		wantPod   string
+		wantEmpty bool
+	}{
+		{"/sys/fs/cgroup/kubepods/burstable/poda1b2c3d4/container-xyz", "poda1b2c3d4", false},
+		{"/sys/fs/cgroup/kubepods/guaranteed/pod-foo-bar/ctr0", "pod-foo-bar", false},
+		{"/sys/fs/cgroup/system.slice/docker-abc123.scope", "docker-abc123.scope", false},
+	}
+	for _, c := range cases {
+		pod, ns := parseCgroupPodNamespace(c.path)
+		if pod == "" {
+			t.Errorf("parseCgroupPodNamespace(%q) pod is empty", c.path)
+		}
+		if c.wantPod != "" && pod != c.wantPod {
+			t.Errorf("parseCgroupPodNamespace(%q) pod = %q, want %q", c.path, pod, c.wantPod)
+		}
+		if ns != "" {
+			t.Errorf("parseCgroupPodNamespace(%q) namespace = %q, want empty", c.path, ns)
+		}
+	}
+}

--- a/internal/collector/cgroup_memory_test.go
+++ b/internal/collector/cgroup_memory_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -195,34 +196,36 @@ func TestCgroupMemoryCollector_StartStop(t *testing.T) {
 }
 
 // TestCgroupMemoryCollector_LeafOnly verifies that when a parent directory
-// and a child directory both have a finite memory.max, only the child (leaf)
-// is reported. This mirrors the real K8s hierarchy where kubepods.slice,
-// pod.slice, and container.scope all have memory.max set.
+// and its direct child both have a finite memory.max — as in a real K8s
+// hierarchy (kubepods.slice → pod-x.slice → container.scope) — only the
+// innermost leaf is reported, not the parent.
 func TestCgroupMemoryCollector_LeafOnly(t *testing.T) {
 	root := t.TempDir()
-
-	// Parent cgroup with a limit — should NOT be reported because its child
-	// also has a limit.
-	parentDir := filepath.Join(root, "kubepods", "burstable", "pod-test")
-	if err := os.MkdirAll(parentDir, 0o750); err != nil {
-		t.Fatal(err)
-	}
-	writeFileAt := func(path, content string) {
+	writeAt := func(path, content string) {
 		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
-	const limitBytes = uint64(512 << 20)
-	writeFileAt(filepath.Join(parentDir, "memory.max"), fmt.Sprintf("%d\n", limitBytes))
-	writeFileAt(filepath.Join(parentDir, "memory.current"), fmt.Sprintf("%d\n", limitBytes/2))
-	writeFileAt(filepath.Join(parentDir, "memory.high"), fmt.Sprintf("%d\n", limitBytes*9/10))
-	writeFileAt(filepath.Join(parentDir, "memory.events"), "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n")
 
-	// Child (leaf) cgroup — the one that should be reported.
-	childDir := filepath.Join(parentDir, "container-0")
-	writeCgroupDir(t, filepath.Join(root, "kubepods", "burstable", "pod-test"), limitBytes, limitBytes*3/4, limitBytes*9/10, 0)
-	// writeCgroupDir creates container-0 under pod-test automatically.
-	_ = childDir
+	// Parent slice — has memory.max but must NOT appear because its child also has one.
+	parent := filepath.Join(root, "kubepods.slice", "pod-x.slice")
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeAt(filepath.Join(parent, "memory.max"), "8589934592\n")     // 8 GiB
+	writeAt(filepath.Join(parent, "memory.current"), "4294967296\n") // 4 GiB
+	writeAt(filepath.Join(parent, "memory.high"), "7516192768\n")
+	writeAt(filepath.Join(parent, "memory.events"), "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n")
+
+	// Leaf container scope — direct child of parent; this is the only entry that should appear.
+	leaf := filepath.Join(parent, "container.scope")
+	if err := os.MkdirAll(leaf, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeAt(filepath.Join(leaf, "memory.max"), "4294967296\n")     // 4 GiB
+	writeAt(filepath.Join(leaf, "memory.current"), "3865470566\n") // ~90 %
+	writeAt(filepath.Join(leaf, "memory.high"), "3865470566\n")
+	writeAt(filepath.Join(leaf, "memory.events"), "low 0\nhigh 2\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n")
 
 	c := NewCgroupMemoryCollector(newSilentLogger(), 50*time.Millisecond)
 	c.cgroupRoot = root
@@ -236,11 +239,10 @@ func TestCgroupMemoryCollector_LeafOnly(t *testing.T) {
 		t.Fatal("expected non-nil snapshot")
 	}
 	if len(snap.Containers) != 1 {
-		t.Fatalf("leaf-only: expected 1 container, got %d (duplicate parent entries)", len(snap.Containers))
+		t.Fatalf("leaf-only: expected 1 entry, got %d (parent was incorrectly included)", len(snap.Containers))
 	}
-	// The reported entry must be the leaf (container-0), not the parent.
-	if snap.Containers[0].CgroupPath == parentDir {
-		t.Errorf("reported parent %q instead of leaf container", parentDir)
+	if !strings.Contains(snap.Containers[0].CgroupPath, "container.scope") {
+		t.Errorf("expected leaf path (container.scope), got %q", snap.Containers[0].CgroupPath)
 	}
 }
 

--- a/internal/collector/cgroup_memory_test.go
+++ b/internal/collector/cgroup_memory_test.go
@@ -16,11 +16,11 @@ import (
 func writeCgroupDir(t *testing.T, root string, limitBytes, currentBytes, highBytes uint64, eventsHigh uint64) string {
 	t.Helper()
 	cgroupPath := filepath.Join(root, "kubepods", "burstable", "pod-test", "container-0")
-	if err := os.MkdirAll(cgroupPath, 0o755); err != nil {
+	if err := os.MkdirAll(cgroupPath, 0o750); err != nil {
 		t.Fatal(err)
 	}
 	writeFile := func(name, content string) {
-		if err := os.WriteFile(filepath.Join(cgroupPath, name), []byte(content), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(cgroupPath, name), []byte(content), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -33,7 +33,7 @@ func writeCgroupDir(t *testing.T, root string, limitBytes, currentBytes, highByt
 
 func TestCgroupMemoryCollector_BasicPoll(t *testing.T) {
 	root := t.TempDir()
-	const limitBytes = 4 << 30  // 4 GiB
+	const limitBytes = 4 << 30   // 4 GiB
 	const currentBytes = 3 << 30 // 3 GiB = 75%
 	writeCgroupDir(t, root, limitBytes, currentBytes, limitBytes*9/10, 0)
 
@@ -69,14 +69,14 @@ func TestCgroupMemoryCollector_BasicPoll(t *testing.T) {
 func TestCgroupMemoryCollector_UnlimitedMax(t *testing.T) {
 	root := t.TempDir()
 	cgroupPath := filepath.Join(root, "container-unlimited")
-	if err := os.MkdirAll(cgroupPath, 0o755); err != nil {
+	if err := os.MkdirAll(cgroupPath, 0o750); err != nil {
 		t.Fatal(err)
 	}
 	// memory.max = "max" means unlimited — should be ignored.
-	if err := os.WriteFile(filepath.Join(cgroupPath, "memory.max"), []byte("max\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cgroupPath, "memory.max"), []byte("max\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cgroupPath, "memory.current"), []byte("1073741824\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cgroupPath, "memory.current"), []byte("1073741824\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -99,7 +99,7 @@ func TestCgroupMemoryCollector_UnlimitedMax(t *testing.T) {
 
 func TestCgroupMemoryCollector_GrowthRate(t *testing.T) {
 	root := t.TempDir()
-	const limitBytes = 1 << 30 // 1 GiB
+	const limitBytes = 1 << 30                                                 // 1 GiB
 	cgPath := writeCgroupDir(t, root, limitBytes, 700<<20, limitBytes*9/10, 0) // 700 MB initial
 
 	c := NewCgroupMemoryCollector(newSilentLogger(), 10*time.Millisecond)
@@ -111,7 +111,7 @@ func TestCgroupMemoryCollector_GrowthRate(t *testing.T) {
 
 	// Simulate memory growth to 800 MB.
 	time.Sleep(50 * time.Millisecond)
-	if err := os.WriteFile(filepath.Join(cgPath, "memory.current"), []byte(fmt.Sprintf("%d\n", 800<<20)), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cgPath, "memory.current"), []byte(fmt.Sprintf("%d\n", 800<<20)), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -143,7 +143,7 @@ func TestCgroupMemoryCollector_HighEventRate(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	// Increment high event counter by 10.
 	events := "low 0\nhigh 15\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n"
-	if err := os.WriteFile(filepath.Join(cgPath, "memory.events"), []byte(events), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cgPath, "memory.events"), []byte(events), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -198,7 +198,7 @@ func TestReadCgroupMemoryEvents(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "memory.events")
 	content := "low 0\nhigh 4\nmax 2\noom 1\noom_kill 1\noom_group_kill 0\n"
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	got := readCgroupMemoryEvents(path)
@@ -210,7 +210,7 @@ func TestReadCgroupMemoryEvents(t *testing.T) {
 	}
 }
 
-func TestParseCgroupPodNamespace(t *testing.T) {
+func TestParseCgroupPod(t *testing.T) {
 	cases := []struct {
 		path      string
 		wantPod   string
@@ -221,15 +221,12 @@ func TestParseCgroupPodNamespace(t *testing.T) {
 		{"/sys/fs/cgroup/system.slice/docker-abc123.scope", "docker-abc123.scope", false},
 	}
 	for _, c := range cases {
-		pod, ns := parseCgroupPodNamespace(c.path)
+		pod := parseCgroupPod(c.path)
 		if pod == "" {
-			t.Errorf("parseCgroupPodNamespace(%q) pod is empty", c.path)
+			t.Errorf("parseCgroupPod(%q) pod is empty", c.path)
 		}
 		if c.wantPod != "" && pod != c.wantPod {
-			t.Errorf("parseCgroupPodNamespace(%q) pod = %q, want %q", c.path, pod, c.wantPod)
-		}
-		if ns != "" {
-			t.Errorf("parseCgroupPodNamespace(%q) namespace = %q, want empty", c.path, ns)
+			t.Errorf("parseCgroupPod(%q) = %q, want %q", c.path, pod, c.wantPod)
 		}
 	}
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -142,6 +142,8 @@ func (r *Registry) Signals(duration time.Duration) *Signals {
 			s.FD = v
 		case *MemorySnapshot:
 			s.Memory = v
+		case *CgroupMemorySnapshot:
+			s.CgroupMemory = v
 		}
 	}
 

--- a/internal/collector/signals.go
+++ b/internal/collector/signals.go
@@ -21,12 +21,12 @@ type Signals struct {
 	Host HostInfo `json:"host"`
 
 	// Per-signal snapshots (nil if collector is disabled or has no data).
-	Syscall *SyscallSnapshot `json:"syscall,omitempty"`
-	TCP     *TCPSnapshot     `json:"tcp,omitempty"`
-	OOM     *OOMSnapshot     `json:"oom,omitempty"`
-	DiskIO  *DiskIOSnapshot  `json:"diskIO,omitempty"`
-	Sched   *SchedSnapshot   `json:"sched,omitempty"`
-	FD      *FDSnapshot      `json:"fd,omitempty"`
+	Syscall      *SyscallSnapshot      `json:"syscall,omitempty"`
+	TCP          *TCPSnapshot          `json:"tcp,omitempty"`
+	OOM          *OOMSnapshot          `json:"oom,omitempty"`
+	DiskIO       *DiskIOSnapshot       `json:"diskIO,omitempty"`
+	Sched        *SchedSnapshot        `json:"sched,omitempty"`
+	FD           *FDSnapshot           `json:"fd,omitempty"`
 	Memory       *MemorySnapshot       `json:"memory,omitempty"`
 	CgroupMemory *CgroupMemorySnapshot `json:"cgroupMemory,omitempty"`
 }

--- a/internal/collector/signals.go
+++ b/internal/collector/signals.go
@@ -27,7 +27,8 @@ type Signals struct {
 	DiskIO  *DiskIOSnapshot  `json:"diskIO,omitempty"`
 	Sched   *SchedSnapshot   `json:"sched,omitempty"`
 	FD      *FDSnapshot      `json:"fd,omitempty"`
-	Memory  *MemorySnapshot  `json:"memory,omitempty"`
+	Memory       *MemorySnapshot       `json:"memory,omitempty"`
+	CgroupMemory *CgroupMemorySnapshot `json:"cgroupMemory,omitempty"`
 }
 
 // HostInfo identifies the machine being observed.
@@ -182,6 +183,45 @@ type FDEntry struct {
 	Closes     uint64  `json:"closes"`
 	NetDelta   int64   `json:"netDelta"`
 	GrowthRate float64 `json:"growthRate"` // FDs per second
+}
+
+// ─── Cgroup Memory Snapshot ──────────────────────────────────────────────────
+
+// CgroupMemorySnapshot holds per-container cgroup v2 memory state, populated
+// by the CgroupMemoryCollector. On systems without cgroup v2 limits this will
+// be nil or contain an empty Containers slice.
+type CgroupMemorySnapshot struct {
+	Containers []CgroupMemoryEntry `json:"containers"`
+}
+
+// CgroupMemoryEntry is the memory state for a single cgroup (container).
+type CgroupMemoryEntry struct {
+	// CgroupPath is the absolute path of the cgroup directory.
+	CgroupPath string `json:"cgroupPath"`
+	// Pod is the pod name or UID extracted from the cgroup path.
+	Pod string `json:"pod"`
+	// Namespace is the Kubernetes namespace (empty when enrichment is not available).
+	Namespace string `json:"namespace"`
+
+	// CurrentBytes is the value of memory.current.
+	CurrentBytes uint64 `json:"currentBytes"`
+	// LimitBytes is the value of memory.max.
+	LimitBytes uint64 `json:"limitBytes"`
+	// HighBytes is the value of memory.high (0 = not set).
+	HighBytes uint64 `json:"highBytes"`
+	// UsedPct is CurrentBytes / LimitBytes * 100.
+	UsedPct float64 `json:"usedPct"`
+
+	// GrowthRateBytesPerSec is the rate of change of CurrentBytes between polls.
+	GrowthRateBytesPerSec float64 `json:"growthRateBytesPerSec"`
+	// HighEventRate is the rate of memory.events.high increments per second.
+	HighEventRate float64 `json:"highEventRate"`
+
+	// Event counters from memory.events.
+	EventsHigh    uint64 `json:"eventsHigh"`
+	EventsMax     uint64 `json:"eventsMax"`
+	EventsOOM     uint64 `json:"eventsOOM"`
+	EventsOOMKill uint64 `json:"eventsOOMKill"`
 }
 
 // ─── Memory Snapshot ─────────────────────────────────────────────────────────

--- a/internal/doctor/rules.go
+++ b/internal/doctor/rules.go
@@ -509,7 +509,7 @@ func evalMemoryLimitPressure(s *collector.Signals) []Finding {
 		return nil
 	}
 
-	var findings []Finding
+	findings := make([]Finding, 0, len(s.CgroupMemory.Containers))
 	for _, c := range s.CgroupMemory.Containers {
 		if c.LimitBytes == 0 || c.UsedPct < 85.0 {
 			continue
@@ -533,12 +533,12 @@ func evalMemoryLimitPressure(s *collector.Signals) []Finding {
 		impact := fmt.Sprintf("OOM kill will terminate container %s if usage reaches the limit", label)
 
 		f := Finding{
-			Severity:  sev,
-			Rule:      "memory_limit_pressure",
-			Title:     title,
-			Signal:    "cgroup_memory",
-			Cause:     fmt.Sprintf("Container memory usage is at %.1f%% of its cgroup limit", c.UsedPct),
-			Impact:    impact,
+			Severity: sev,
+			Rule:     "memory_limit_pressure",
+			Title:    title,
+			Signal:   "cgroup_memory",
+			Cause:    fmt.Sprintf("Container memory usage is at %.1f%% of its cgroup limit", c.UsedPct),
+			Impact:   impact,
 			Evidence: fmt.Sprintf(
 				"current=%s limit=%s used=%.1f%% growth=%.1f MB/s events(high=%d oom=%d oom_kill=%d)",
 				formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes), c.UsedPct,
@@ -589,7 +589,7 @@ func evalMemoryHighThrottling(s *collector.Signals) []Finding {
 		return nil
 	}
 
-	var findings []Finding
+	findings := make([]Finding, 0, len(s.CgroupMemory.Containers))
 	for _, c := range s.CgroupMemory.Containers {
 		if c.HighEventRate < 1.0 {
 			continue

--- a/internal/doctor/rules.go
+++ b/internal/doctor/rules.go
@@ -517,7 +517,7 @@ func evalMemoryLimitPressure(s *collector.Signals) []Finding {
 
 		sev := SeverityWarning
 		threshold := 85.0
-		if c.UsedPct > 95.0 && c.GrowthRateBytesPerSec > 0 {
+		if c.UsedPct >= 95.0 && c.GrowthRateBytesPerSec > 0 {
 			sev = SeverityCritical
 			threshold = 95.0
 		}

--- a/internal/doctor/rules.go
+++ b/internal/doctor/rules.go
@@ -28,6 +28,8 @@ func Evaluate(signals *collector.Signals, thresholds config.DoctorThresholds) []
 	findings = append(findings, evalSyscallLatencyHigh(signals, thresholds)...)
 	findings = append(findings, evalOOMImminent(signals, thresholds)...)
 	findings = append(findings, evalSyscallErrorRate(signals)...)
+	findings = append(findings, evalMemoryLimitPressure(signals)...)
+	findings = append(findings, evalMemoryHighThrottling(signals)...)
 
 	// If nothing found, emit "healthy system" info.
 	if len(findings) == 0 {
@@ -495,6 +497,132 @@ func evalSyscallErrorRate(s *collector.Signals) []Finding {
 		Threshold: 1.0,
 		Process:   top.entry.Comm,
 	}}
+}
+
+// ── Rule 12: Memory Limit Pressure ──────────────────────────────────────────
+
+// evalMemoryLimitPressure fires for each container that is close to its
+// cgroup v2 memory.max limit. WARNING at >85 %; CRITICAL at >95 % with
+// positive growth rate. Includes an ETA when growth rate exceeds 1 MB/s.
+func evalMemoryLimitPressure(s *collector.Signals) []Finding {
+	if s.CgroupMemory == nil {
+		return nil
+	}
+
+	var findings []Finding
+	for _, c := range s.CgroupMemory.Containers {
+		if c.LimitBytes == 0 || c.UsedPct < 85.0 {
+			continue
+		}
+
+		sev := SeverityWarning
+		if c.UsedPct > 95.0 && c.GrowthRateBytesPerSec > 0 {
+			sev = SeverityCritical
+		}
+
+		label := c.Pod
+		if c.Namespace != "" {
+			label = c.Namespace + "/" + c.Pod
+		}
+
+		growthMBs := c.GrowthRateBytesPerSec / (1024 * 1024)
+
+		title := fmt.Sprintf("%s is %.0f%% of its memory limit (%s / %s)",
+			label, c.UsedPct, formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes))
+
+		impact := fmt.Sprintf("OOM kill will terminate container %s if usage reaches the limit", label)
+
+		f := Finding{
+			Severity:  sev,
+			Rule:      "memory_limit_pressure",
+			Title:     title,
+			Signal:    "cgroup_memory",
+			Cause:     fmt.Sprintf("Container memory usage is at %.1f%% of its cgroup limit", c.UsedPct),
+			Impact:    impact,
+			Evidence: fmt.Sprintf(
+				"current=%s limit=%s used=%.1f%% growth=%.1f MB/s events(high=%d oom=%d oom_kill=%d)",
+				formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes), c.UsedPct,
+				growthMBs, c.EventsHigh, c.EventsOOM, c.EventsOOMKill),
+			Fix: []string{
+				fmt.Sprintf("Increase the memory limit for pod %s", c.Pod),
+				"Profile heap usage: kubectl exec ... -- pprof / jmap / go tool pprof",
+				"Consider setting memory.high to enable soft throttling before OOM",
+			},
+			Metric:    "cgroup_memory_used_pct",
+			Value:     c.UsedPct,
+			Threshold: 85.0,
+			Process:   c.Pod,
+		}
+
+		// ETA is only meaningful when growth rate is significant (>1 MB/s).
+		if sev == SeverityCritical {
+			const minGrowthForETA = 1 << 20 // 1 MB/s
+			if c.GrowthRateBytesPerSec >= minGrowthForETA && c.LimitBytes > c.CurrentBytes {
+				remaining := c.LimitBytes - c.CurrentBytes
+				etaSecs := float64(remaining) / c.GrowthRateBytesPerSec
+				eta := time.Duration(etaSecs) * time.Second
+				f.ETA = &eta
+				f.Impact = fmt.Sprintf(
+					"%s is %.0f%% of its memory limit (%s / %s) and growing %.1f MB/s. OOMKill expected in %s.",
+					label, c.UsedPct,
+					formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes),
+					growthMBs, f.ETAString())
+			} else {
+				f.Impact = fmt.Sprintf(
+					"%s is %.0f%% of its memory limit (%s / %s) and trending up, but no reliable ETA available (growth rate < 1 MB/s).",
+					label, c.UsedPct, formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes))
+			}
+		}
+
+		findings = append(findings, f)
+	}
+	return findings
+}
+
+// ── Rule 13: Memory High Throttling ─────────────────────────────────────────
+
+// evalMemoryHighThrottling fires when the kernel is reclaiming memory under
+// the memory.high soft limit at a sustained rate of more than 1 event/sec.
+// This is an early warning before any OOM kill.
+func evalMemoryHighThrottling(s *collector.Signals) []Finding {
+	if s.CgroupMemory == nil {
+		return nil
+	}
+
+	var findings []Finding
+	for _, c := range s.CgroupMemory.Containers {
+		if c.HighEventRate < 1.0 {
+			continue
+		}
+
+		label := c.Pod
+		if c.Namespace != "" {
+			label = c.Namespace + "/" + c.Pod
+		}
+
+		findings = append(findings, Finding{
+			Severity: SeverityWarning,
+			Rule:     "memory_high_throttling",
+			Title:    fmt.Sprintf("Memory High Throttling: %s", label),
+			Signal:   "cgroup_memory",
+			Cause: fmt.Sprintf(
+				"Kernel is reclaiming memory under memory.high pressure at %.1f events/sec", c.HighEventRate),
+			Impact: "Container throughput is being throttled; risk of OOMKill increases if usage continues to rise",
+			Evidence: fmt.Sprintf(
+				"high_event_rate=%.1f/sec high_limit=%s current=%s max=%s",
+				c.HighEventRate, formatBytes(c.HighBytes), formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes)),
+			Fix: []string{
+				fmt.Sprintf("Increase the memory limit or memory.high setting for pod %s", c.Pod),
+				"Review memory allocation patterns and look for unexpected growth",
+				"Check for memory leaks: heap profile or smem",
+			},
+			Metric:    "cgroup_memory_high_event_rate",
+			Value:     c.HighEventRate,
+			Threshold: 1.0,
+			Process:   c.Pod,
+		})
+	}
+	return findings
 }
 
 // formatBytes returns a human-readable byte size.

--- a/internal/doctor/rules.go
+++ b/internal/doctor/rules.go
@@ -516,8 +516,10 @@ func evalMemoryLimitPressure(s *collector.Signals) []Finding {
 		}
 
 		sev := SeverityWarning
+		threshold := 85.0
 		if c.UsedPct > 95.0 && c.GrowthRateBytesPerSec > 0 {
 			sev = SeverityCritical
+			threshold = 95.0
 		}
 
 		label := c.Pod
@@ -550,7 +552,7 @@ func evalMemoryLimitPressure(s *collector.Signals) []Finding {
 			},
 			Metric:    "cgroup_memory_used_pct",
 			Value:     c.UsedPct,
-			Threshold: 85.0,
+			Threshold: threshold,
 			Process:   c.Pod,
 		}
 

--- a/internal/doctor/rules_test.go
+++ b/internal/doctor/rules_test.go
@@ -543,6 +543,34 @@ func TestEvaluate_MemoryLimitPressure_CriticalNoETA(t *testing.T) {
 	t.Error("expected CRITICAL memory_limit_pressure finding")
 }
 
+func TestEvaluate_MemoryLimitPressure_ExactlyAt95(t *testing.T) {
+	limit := uint64(4 << 30)
+	signals := &collector.Signals{
+		CgroupMemory: &collector.CgroupMemorySnapshot{
+			Containers: []collector.CgroupMemoryEntry{
+				{
+					Pod:                   "pod-boundary",
+					LimitBytes:            limit,
+					CurrentBytes:          uint64(float64(limit) * 0.95),
+					UsedPct:               95.0,
+					GrowthRateBytesPerSec: 2 * 1024 * 1024, // 2 MB/s — growing
+				},
+			},
+		},
+	}
+
+	findings := Evaluate(signals, defaultThresholds())
+	for _, f := range findings {
+		if f.Rule == "memory_limit_pressure" {
+			if f.Severity != SeverityCritical {
+				t.Errorf("expected CRITICAL at exactly 95%%, got %s", f.Severity)
+			}
+			return
+		}
+	}
+	t.Error("expected memory_limit_pressure finding at exactly 95%")
+}
+
 func TestEvaluate_MemoryLimitPressure_BelowThreshold(t *testing.T) {
 	limit := uint64(4 << 30)
 	signals := &collector.Signals{

--- a/internal/doctor/rules_test.go
+++ b/internal/doctor/rules_test.go
@@ -446,6 +446,233 @@ func TestEvaluate_SyscallErrorRate_BelowThreshold(t *testing.T) {
 	}
 }
 
+func TestEvaluate_MemoryLimitPressure_Warning(t *testing.T) {
+	limitBytes := uint64(4 << 30)
+	currentBytes := uint64(float64(limitBytes) * 0.88)
+	signals := &collector.Signals{
+		CgroupMemory: &collector.CgroupMemorySnapshot{
+			Containers: []collector.CgroupMemoryEntry{
+				{
+					CgroupPath:   "/sys/fs/cgroup/kubepods/burstable/pod-redis/ctr0",
+					Pod:          "pod-redis",
+					LimitBytes:   limitBytes,
+					CurrentBytes: currentBytes,
+					UsedPct:      88.0,
+				},
+			},
+		},
+	}
+
+	findings := Evaluate(signals, defaultThresholds())
+	found := false
+	for _, f := range findings {
+		if f.Rule == "memory_limit_pressure" && f.Severity == SeverityWarning {
+			found = true
+			if f.Process != "pod-redis" {
+				t.Errorf("expected Process=pod-redis, got %q", f.Process)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected WARNING memory_limit_pressure at 88%")
+	}
+}
+
+func TestEvaluate_MemoryLimitPressure_CriticalWithETA(t *testing.T) {
+	limit := uint64(4 << 30) // 4 GiB
+	signals := &collector.Signals{
+		CgroupMemory: &collector.CgroupMemorySnapshot{
+			Containers: []collector.CgroupMemoryEntry{
+				{
+					CgroupPath:            "/sys/fs/cgroup/kubepods/burstable/pod-kafka/ctr0",
+					Pod:                   "pod-kafka",
+					LimitBytes:            limit,
+					CurrentBytes:          uint64(float64(limit) * 0.96),
+					UsedPct:               96.0,
+					GrowthRateBytesPerSec: 7.2 * 1024 * 1024, // 7.2 MB/s
+				},
+			},
+		},
+	}
+
+	findings := Evaluate(signals, defaultThresholds())
+	found := false
+	for _, f := range findings {
+		if f.Rule == "memory_limit_pressure" && f.Severity == SeverityCritical {
+			found = true
+			if f.ETA == nil {
+				t.Error("expected ETA for critical memory_limit_pressure with growth > 1 MB/s")
+			}
+			if f.Process != "pod-kafka" {
+				t.Errorf("expected Process=pod-kafka, got %q", f.Process)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected CRITICAL memory_limit_pressure at 96% + growing")
+	}
+}
+
+func TestEvaluate_MemoryLimitPressure_CriticalNoETA(t *testing.T) {
+	limit := uint64(4 << 30)
+	signals := &collector.Signals{
+		CgroupMemory: &collector.CgroupMemorySnapshot{
+			Containers: []collector.CgroupMemoryEntry{
+				{
+					Pod:                   "pod-slow",
+					LimitBytes:            limit,
+					CurrentBytes:          uint64(float64(limit) * 0.97),
+					UsedPct:               97.0,
+					GrowthRateBytesPerSec: 500 * 1024, // 500 KB/s — below 1 MB/s threshold
+				},
+			},
+		},
+	}
+
+	findings := Evaluate(signals, defaultThresholds())
+	for _, f := range findings {
+		if f.Rule == "memory_limit_pressure" && f.Severity == SeverityCritical {
+			if f.ETA != nil {
+				t.Error("should not compute ETA when growth rate < 1 MB/s")
+			}
+			return
+		}
+	}
+	t.Error("expected CRITICAL memory_limit_pressure finding")
+}
+
+func TestEvaluate_MemoryLimitPressure_BelowThreshold(t *testing.T) {
+	limit := uint64(4 << 30)
+	signals := &collector.Signals{
+		CgroupMemory: &collector.CgroupMemorySnapshot{
+			Containers: []collector.CgroupMemoryEntry{
+				{
+					Pod:          "pod-ok",
+					LimitBytes:   limit,
+					CurrentBytes: uint64(float64(limit) * 0.70),
+					UsedPct:      70.0,
+				},
+			},
+		},
+	}
+
+	findings := Evaluate(signals, defaultThresholds())
+	for _, f := range findings {
+		if f.Rule == "memory_limit_pressure" {
+			t.Error("should not fire memory_limit_pressure at 70%")
+		}
+	}
+}
+
+func TestEvaluate_MemoryLimitPressure_NilCgroupMemory(t *testing.T) {
+	signals := &collector.Signals{}
+	findings := Evaluate(signals, defaultThresholds())
+	for _, f := range findings {
+		if f.Rule == "memory_limit_pressure" {
+			t.Error("should not fire memory_limit_pressure when CgroupMemory is nil")
+		}
+	}
+}
+
+func TestEvaluate_MemoryHighThrottling_Warning(t *testing.T) {
+	limit := uint64(2 << 30)
+	signals := &collector.Signals{
+		CgroupMemory: &collector.CgroupMemorySnapshot{
+			Containers: []collector.CgroupMemoryEntry{
+				{
+					Pod:           "pod-throttled",
+					LimitBytes:    limit,
+					CurrentBytes:  uint64(float64(limit) * 0.82),
+					UsedPct:       82.0,
+					HighBytes:     uint64(float64(limit) * 0.80),
+					HighEventRate: 3.5, // 3.5 events/sec > 1/sec threshold
+				},
+			},
+		},
+	}
+
+	findings := Evaluate(signals, defaultThresholds())
+	found := false
+	for _, f := range findings {
+		if f.Rule == "memory_high_throttling" && f.Severity == SeverityWarning {
+			found = true
+			if f.Process != "pod-throttled" {
+				t.Errorf("expected Process=pod-throttled, got %q", f.Process)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected WARNING memory_high_throttling at 3.5 events/sec")
+	}
+}
+
+func TestEvaluate_MemoryHighThrottling_BelowThreshold(t *testing.T) {
+	signals := &collector.Signals{
+		CgroupMemory: &collector.CgroupMemorySnapshot{
+			Containers: []collector.CgroupMemoryEntry{
+				{
+					Pod:           "pod-ok",
+					LimitBytes:    2 << 30,
+					CurrentBytes:  1 << 29,
+					UsedPct:       25.0,
+					HighEventRate: 0.5, // < 1/sec
+				},
+			},
+		},
+	}
+
+	findings := Evaluate(signals, defaultThresholds())
+	for _, f := range findings {
+		if f.Rule == "memory_high_throttling" {
+			t.Error("should not fire memory_high_throttling at 0.5 events/sec")
+		}
+	}
+}
+
+func TestEvaluate_MemoryLimitPressure_WithNamespace(t *testing.T) {
+	limit := uint64(4 << 30)
+	signals := &collector.Signals{
+		CgroupMemory: &collector.CgroupMemorySnapshot{
+			Containers: []collector.CgroupMemoryEntry{
+				{
+					Pod:                   "kafka-broker-2",
+					Namespace:             "production",
+					LimitBytes:            limit,
+					CurrentBytes:          uint64(float64(limit) * 0.96),
+					UsedPct:               96.0,
+					GrowthRateBytesPerSec: 7.2 * 1024 * 1024,
+				},
+			},
+		},
+	}
+
+	findings := Evaluate(signals, defaultThresholds())
+	for _, f := range findings {
+		if f.Rule == "memory_limit_pressure" {
+			if !containsString(f.Title, "production/kafka-broker-2") {
+				t.Errorf("expected namespace/pod in title, got: %q", f.Title)
+			}
+			return
+		}
+	}
+	t.Error("expected memory_limit_pressure finding")
+}
+
+func containsString(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}
+
 func TestEvaluate_MultipleFindings(t *testing.T) {
 	signals := &collector.Signals{
 		DiskIO: &collector.DiskIOSnapshot{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -117,12 +117,13 @@ var FDCloseTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 // ─── Cgroup Memory Metrics ────────────────────────────────────────────────
 
 // CgroupMemoryPressurePct tracks per-container memory usage as a percentage
-// of the cgroup memory limit. Labeled by pod and namespace.
+// of the cgroup memory limit. Labeled by pod only; namespace label will be
+// added once the Kubernetes enrichment path lands end-to-end.
 var CgroupMemoryPressurePct = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: Namespace,
 	Name:      "cgroup_memory_pressure_pct",
 	Help:      "Per-container memory usage as a percentage of the cgroup memory.max limit.",
-}, []string{"pod", "namespace"})
+}, []string{"pod"})
 
 // ─── Self-Monitoring Metrics ──────────────────────────────────────────────
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -114,6 +114,16 @@ var FDCloseTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Help:      "Total file descriptor close operations.",
 }, []string{"process"})
 
+// ─── Cgroup Memory Metrics ────────────────────────────────────────────────
+
+// CgroupMemoryPressurePct tracks per-container memory usage as a percentage
+// of the cgroup memory limit. Labeled by pod and namespace.
+var CgroupMemoryPressurePct = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: Namespace,
+	Name:      "cgroup_memory_pressure_pct",
+	Help:      "Per-container memory usage as a percentage of the cgroup memory.max limit.",
+}, []string{"pod", "namespace"})
+
 // ─── Self-Monitoring Metrics ──────────────────────────────────────────────
 
 // CollectorEventsTotal counts events processed per collector.
@@ -163,6 +173,8 @@ func init() {
 		// FD
 		FDOpenTotal,
 		FDCloseTotal,
+		// Cgroup memory
+		CgroupMemoryPressurePct,
 		// Self-monitoring
 		CollectorEventsTotal,
 		CollectorErrorsTotal,

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -294,23 +294,32 @@ phase_induce_detect() {
     echo "==> 9. induce → detect pairings"
     local n=$1
 
+    # Format: "scenario:rule" or "scenario:rule:ENV=val" when the doctor
+    # invocation needs an extra environment variable (e.g. cgroup-memory
+    # writes to /tmp and requires KERNO_CGROUP_ROOT to be pointed there).
     local pairings=(
         "disk-sat:disk_io_bottleneck"
         "fd-leak:fd_leak"
         "cpu:scheduler_contention"
         "tcp-churn:scheduler_contention"
+        "cgroup-memory:memory_limit_pressure:KERNO_CGROUP_ROOT=/tmp/kerno-chaos-cgroup"
     )
 
     for p in "${pairings[@]}"; do
-        local scenario="${p%%:*}"
-        local expected="${p##*:}"
+        local scenario expected doctor_env
+        scenario="${p%%:*}"
+        rest="${p#*:}"
+        expected="${rest%%:*}"
+        doctor_env="${rest#*:}"
+        # doctor_env equals expected when there is no third field.
+        [[ "$doctor_env" == "$expected" ]] && doctor_env=""
 
         "$KERNO" chaos --induce "$scenario" --duration 12s --intensity high --yes \
             >/tmp/verify-chaos-"$scenario"-id.log 2>&1 &
         local cpid=$!
         sleep 1
 
-        sudo "$KERNO" --config scripts/verify-config.yaml \
+        env $doctor_env sudo -E "$KERNO" --config scripts/verify-config.yaml \
             doctor --duration 10s --output json \
             >/tmp/verify-doctor-"$scenario".json 2>/tmp/verify-doctor-"$scenario".log
 


### PR DESCRIPTION
## Summary

Implements #21 — per-container cgroup v2 memory monitoring that **predicts OOMKills before they happen** rather than detecting them after the fact.

- **New `CgroupMemoryCollector`** polls `/sys/fs/cgroup` every 5s, walks the cgroup hierarchy, and reads `memory.current` / `memory.max` / `memory.high` / `memory.events` per container. Growth rate and high-event rate are computed from successive samples.
- **New rule `memory_limit_pressure`**: WARNING at >85%, CRITICAL at >95% with positive growth. Computes `ETA = (max − current) / growth_rate` when growth ≥ 1 MB/s, otherwise says _"trending up but no reliable ETA available"_. Finding text matches the spec: `kafka-broker-2 is 96% of its memory limit (3.84 / 4.00 GiB) and growing 7.2 MB/s. OOMKill expected in ~22s.`
- **New rule `memory_high_throttling`**: WARNING when `memory.events.high` increments faster than 1/sec (kernel reclaiming under soft limit before any kill).
- **Prometheus metric** `kerno_cgroup_memory_pressure_pct{pod,namespace}` Gauge.
- **New chaos scenario `cgroup-memory`**: creates simulated cgroup files under `/tmp/kerno-chaos-cgroup/` growing 80→97% of `memory.max`. Pairs with `memory_limit_pressure`. No root required, no real K8s pod needed.
- **Bare-metal safety**: collector returns nil when no cgroup memory limits are set — both rules return nil immediately.

## Changed files

| File | Purpose |
|---|---|
| `internal/collector/cgroup_memory.go` | New CgroupMemoryCollector |
| `internal/collector/cgroup_memory_test.go` | Fixture-based tests with simulated `/sys/fs/cgroup` |
| `internal/collector/signals.go` | `CgroupMemorySnapshot` + `CgroupMemoryEntry` types; `CgroupMemory` field on `Signals` |
| `internal/doctor/rules.go` | `evalMemoryLimitPressure` + `evalMemoryHighThrottling` rules, wired into `Evaluate()` |
| `internal/doctor/rules_test.go` | Rule tests: warning, critical+ETA, critical no-ETA, below-threshold, nil, namespace enrichment, throttling |
| `internal/metrics/metrics.go` | `kerno_cgroup_memory_pressure_pct` GaugeVec |
| `internal/chaos/memory.go` | `CgroupMemoryScenario` (`cgroup-memory`) |
| `internal/chaos/paired_rule_test.go` | New rule names registered |

## Acceptance criteria checklist

- [x] Per-container `MemoryLimitPressureFinding` with pod/namespace enrichment
- [x] ETA computation — sensible numbers when growth ≥ 1 MB/s; graceful "no ETA" when growth < 1 MB/s
- [x] Bare-metal: returns nil when no cgroup memory limits are set
- [x] Prometheus metric `kerno_cgroup_memory_pressure_pct{pod,namespace}` Gauge
- [x] Test fixture: simulated `/sys/fs/cgroup` files with growing usage; rule fires at the right thresholds
- [x] Chaos scenario `cgroup-memory` paired with `memory_limit_pressure`

## Test plan

```bash
# Unit tests (no Linux / root required)
go test ./internal/collector/... ./internal/doctor/... ./internal/metrics/...

# Exercise the chaos scenario + rule end-to-end (requires Linux)
kerno chaos --induce cgroup-memory --duration 60s &
kerno doctor --cgroup-root=/tmp/kerno-chaos-cgroup
```