### PR TITLE
fix(ci): provide underscored inputs for first-interaction action

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/first-interaction@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          issue-message: &issue_msg |
             Welcome to **Kerno**, and thanks for opening your first issue! 🎉
 
             A maintainer will triage this within 48 hours. While you wait:
@@ -31,7 +31,8 @@ jobs:
             - 💬 [Discussions](https://github.com/optiqor/kerno/discussions) for questions and design talk
 
             Tip: if you can paste output of `sudo ./bin/bpf-verify` (or `kerno preflight` when it ships) we'll diagnose 90% faster.
-          pr-message: |
+          issue_message: *issue_msg
+          pr-message: &pr_msg |
             🚀 **First PR — welcome aboard!**
 
             A few things to expect:
@@ -42,3 +43,4 @@ jobs:
             4. **Review**: a maintainer will review within 72 hours. Suggestions are conversations, not orders — push back if something doesn't fit your context.
 
             If you get stuck, reply here or jump to [Discussions](https://github.com/optiqor/kerno/discussions). We want this PR to land.
+          pr_message: *pr_msg


### PR DESCRIPTION
<!--
Thanks for contributing to Kerno! A few notes:

- PR title must follow Conventional Commits: `feat(scope): subject` (linted in CI).
- Every commit must be DCO-signed (`git commit -s`).
- Squash merges are the default — your PR title becomes the merge commit.
- CI runs build + race tests + lint + (when configured) the kernel matrix.
-->

This PR updates the `welcome.yml` workflow to provide underscored versions of the input keys (`issue_message` and `pr_message`) required by the `actions/first-interaction@v3` action.

<!-- 1–2 sentences. What does this PR change? -->

The current workflow was failing with `Error: Input required and not supplied: issue_message` because it only provided the hyphenated versions (`issue-message`).

<!-- Link the issue. -->
Fixes #

Used YAML anchors (`&` and `*`) to provide both the  hyphenated and underscored versions of the messages. This ensures compatibility with the action's internal      parsing while keeping the workflow file readable and DRY.

<!-- Notable design decisions, tradeoffs, or implementation notes. Keep it short. -->

## Testing

- [x] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] Tested locally with: <!-- e.g. `sudo ./bin/kerno doctor --duration 5s` -->

<!-- Required for changes touching internal/bpf/, internal/collector/, internal/doctor/. -->

- [ ] N/A — pure docs/refactor
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed
- [ ] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`
