### PR TITLE
feat(cli): add --no-banner flag to suppress ASCII header

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -32,6 +32,7 @@ func newDoctorCmd() *cobra.Command {
 		useAI      bool
 		noAI       bool
 		quiet      bool
+		noBanner   bool
 	)
 
 	cmd := &cobra.Command{
@@ -80,6 +81,7 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
 				output:     output,
 				aiEnabled:  aiEnabled,
 				quiet:      quiet,
+				noBanner:   noBanner,
 			})
 		},
 	}
@@ -93,6 +95,7 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
 	flags.BoolVar(&useAI, "ai", false, "enable AI-powered analysis (requires API key)")
 	flags.BoolVar(&noAI, "no-ai", false, "disable AI analysis even if enabled in config")
 	flags.BoolVarP(&quiet, "quiet", "q", false, "only emit critical/warning findings (CI-friendly)")
+	flags.BoolVar(&noBanner, "no-banner", false, "suppress the ASCII banner block")
 
 	return cmd
 }
@@ -105,6 +108,7 @@ type doctorOpts struct {
 	output     string
 	aiEnabled  bool
 	quiet      bool
+	noBanner   bool
 }
 
 func runDoctor(ctx context.Context, opts doctorOpts) error {
@@ -146,7 +150,8 @@ func runDoctor(ctx context.Context, opts doctorOpts) error {
 		renderer = &doctor.JSONRenderer{Pretty: true}
 	default:
 		renderer = &doctor.PrettyRenderer{
-			NoColor: os.Getenv("NO_COLOR") != "" || !isTerminal(),
+			NoColor:  os.Getenv("NO_COLOR") != "" || !isTerminal(),
+			NoBanner: opts.noBanner,
 		}
 	}
 

--- a/internal/cli/doctor_flags_test.go
+++ b/internal/cli/doctor_flags_test.go
@@ -13,7 +13,7 @@ import (
 func TestNewDoctorCmd_Flags(t *testing.T) {
 	cmd := newDoctorCmd()
 
-	wantFlags := []string{"duration", "exit-code", "continuous", "interval", "output", "ai", "no-ai"}
+	wantFlags := []string{"duration", "exit-code", "continuous", "interval", "output", "ai", "no-ai", "no-banner"}
 	for _, name := range wantFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("doctor cmd missing --%s flag", name)
@@ -43,6 +43,7 @@ func TestNewDoctorCmd_Defaults(t *testing.T) {
 		{"continuous", "false"},
 		{"ai", "false"},
 		{"no-ai", "false"},
+		{"no-banner", "false"},
 	}
 	for _, c := range cases {
 		f := cmd.Flags().Lookup(c.flag)

--- a/internal/doctor/render.go
+++ b/internal/doctor/render.go
@@ -22,7 +22,8 @@ type Renderer interface {
 // PrettyRenderer outputs a human-readable incident report with ANSI colors,
 // box-drawn finding cards, and bar-chart signal visualizations.
 type PrettyRenderer struct {
-	NoColor bool
+	NoColor  bool
+	NoBanner bool
 }
 
 const (
@@ -67,7 +68,11 @@ func newPalette(noColor bool) palette {
 
 func (r *PrettyRenderer) Render(w io.Writer, report *Report) error {
 	p := newPalette(r.NoColor)
-	r.renderHeader(w, report, p)
+
+	if !r.NoBanner {
+		r.renderHeader(w, report, p)
+	}
+
 	r.renderDegradation(w, report, p)
 	r.renderTriage(w, report, p)
 	for i := range report.Findings {

--- a/internal/doctor/render_test.go
+++ b/internal/doctor/render_test.go
@@ -84,6 +84,27 @@ func TestPrettyRenderer_ContainsHeader(t *testing.T) {
 	}
 }
 
+func TestPrettyRenderer_NoBanner(t *testing.T) {
+	var buf bytes.Buffer
+	// Set NoBanner to true
+	r := &PrettyRenderer{NoColor: true, NoBanner: true}
+	report := sampleReport()
+
+	if err := r.Render(&buf, report); err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	output := buf.String()
+
+	if strings.Contains(output, "KERNO DOCTOR") {
+		t.Error("pretty output should NOT contain KERNO DOCTOR banner when NoBanner is true")
+	}
+
+	if !strings.Contains(output, "FINDINGS") {
+		t.Error("pretty output should still contain FINDINGS")
+	}
+}
+
 func TestPrettyRenderer_HealthySystem(t *testing.T) {
 	var buf bytes.Buffer
 	r := &PrettyRenderer{NoColor: true}


### PR DESCRIPTION
Adds a boolean flag to the doctor command to hide the ASCII art logo and metadata. This improves readability in CI/CD logs and automated environments. Includes updated PrettyRenderer logic and new unit tests.

<!--
Thanks for contributing to Kerno! A few notes:

- PR title must follow Conventional Commits: `feat(scope): subject` (linted in CI).
- Every commit must be DCO-signed (`git commit -s`).
- Squash merges are the default — your PR title becomes the merge commit.
- CI runs build + race tests + lint + (when configured) the kernel matrix.
-->

## What

This PR adds a `--no-banner` boolean flag to the `kerno doctor` command. When enabled, it suppresses the ASCII art logo and metadata header.

## Why

The large ASCII banner is helpful for interactive terminal use but creates unnecessary vertical noise in CI/CD logs, Slack integrations, and automated diagnostic reports.

Fixes #9 

## How

- **CLI Flag:** Added `NoBanner` to the `doctorOpts` struct using Cobra's flag system.
- **Logic Implementation:** Updated the `PrettyRenderer` in `internal/doctor/render.go` to wrap the header rendering logic in a conditional check.
- **Cleanup:** Ran `go fmt` to ensure the codebase remains idiomatic.

## Testing

- [ x] `go build ./...` passes
- [ x] `go test ./...` passes
- [ x] `go vet ./...` passes
- [ x] `golangci-lint run ./...` passes
- [ x] Tested locally with: <!-- e.g. `sudo ./bin/kerno doctor --duration 5s` -->

<!-- Required for changes touching internal/bpf/, internal/collector/, internal/doctor/. -->

- [ ] N/A — pure docs/refactor
- [x ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ x] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [ x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x ] All commits are DCO-signed (`git commit -s`)
- [x ] No unrelated changes pulled in
- [ ] Documentation updated where user-visible behavior changed
- [x ] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`
