### PR TITLE
feat(cli): add doctor --list-rules flag

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -35,6 +36,7 @@ func newDoctorCmd() *cobra.Command {
 		quiet        bool
 		noBanner     bool
 		onlyCritical bool
+		listRules    bool
 	)
 
 	cmd := &cobra.Command{
@@ -61,6 +63,11 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
   sudo kerno doctor --ai`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if listRules {
+				printRuleCatalog(os.Stdout)
+				return nil
+			}
+
 			// Inherit --output from root if not set via doctor flag.
 			if output == "" {
 				output, _ = cmd.Root().PersistentFlags().GetString("output")
@@ -100,11 +107,30 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
 	flags.BoolVarP(&quiet, "quiet", "q", false, "only emit critical/warning findings (CI-friendly)")
 	flags.BoolVar(&noBanner, "no-banner", false, "suppress the ASCII banner block")
 	flags.BoolVar(&onlyCritical, "only-critical", false, "show only critical severity items")
+	flags.BoolVar(&listRules, "list-rules", false, "list all diagnostic rules and exit")
 	//nolint:errcheck // RegisterFlagCompletionFunc only returns error on invalid flag name, which is static.
 	_ = cmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"pretty", "json"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	return cmd
+}
+
+func printRuleCatalog(w io.Writer) {
+	tw := tabwriter.NewWriter(w, 0, 0, 4, ' ', 0)
+
+	fmt.Fprintln(tw, "RULE\tSEVERITY\tTHRESHOLD")
+
+	for _, rule := range doctor.ListRules() {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n",
+			rule.Name,
+			rule.Severity,
+			rule.Threshold,
+		)
+	}
+
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to flush rule catalog: %v\n", err)
+	}
 }
 
 type doctorOpts struct {

--- a/internal/doctor/rules.go
+++ b/internal/doctor/rules.go
@@ -13,6 +13,85 @@ import (
 	"github.com/optiqor/kerno/internal/config"
 )
 
+// RuleInfo contains metadata about a diagnostic rule.
+type RuleInfo struct {
+	Name      string
+	Severity  Severity
+	Threshold string
+}
+
+// ListRules returns a static catalog of all possible rules that can be
+// emitted by the diagnostic engine, in the same order they are evaluated.
+func ListRules() []RuleInfo {
+	return []RuleInfo{
+		{
+			Name:      "disk_io_bottleneck",
+			Severity:  SeverityCritical,
+			Threshold: "fsync p99 > 50ms OR queue > 8",
+		},
+		{
+			Name:      "disk_io_write_high",
+			Severity:  SeverityCritical,
+			Threshold: "write p99 > 200ms",
+		},
+		{
+			Name:      "oom_kill_occurred",
+			Severity:  SeverityCritical,
+			Threshold: "OOM kill detected",
+		},
+		{
+			Name:      "tcp_retransmit_storm",
+			Severity:  SeverityCritical,
+			Threshold: "retransmit rate > 2%",
+		},
+		{
+			Name:      "tcp_rtt_degradation",
+			Severity:  SeverityWarning,
+			Threshold: "RTT p99 elevated",
+		},
+		{
+			Name:      "scheduler_contention",
+			Severity:  SeverityCritical,
+			Threshold: "runqueue latency elevated",
+		},
+		{
+			Name:      "fd_leak",
+			Severity:  SeverityWarning,
+			Threshold: "FD growth exceeds threshold",
+		},
+		{
+			Name:      "syscall_latency_high",
+			Severity:  SeverityWarning,
+			Threshold: "syscall p99 latency elevated",
+		},
+		{
+			Name:      "oom_imminent",
+			Severity:  SeverityCritical,
+			Threshold: "memory > 90% with positive growth",
+		},
+		{
+			Name:      "syscall_error_rate",
+			Severity:  SeverityWarning,
+			Threshold: "syscall error rate elevated",
+		},
+		{
+			Name:      "memory_limit_pressure",
+			Severity:  SeverityWarning,
+			Threshold: "container nearing memory limit",
+		},
+		{
+			Name:      "memory_high_throttling",
+			Severity:  SeverityWarning,
+			Threshold: "memory reclaim pressure detected",
+		},
+		{
+			Name:      "healthy_system",
+			Severity:  SeverityInfo,
+			Threshold: "no abnormal kernel signals detected",
+		},
+	}
+}
+
 // Evaluate runs all diagnostic rules against the collected signals and returns
 // findings sorted by severity. This is the deterministic core of kerno doctor —
 // no AI, no network calls, always available.

--- a/internal/doctor/rules.go
+++ b/internal/doctor/rules.go
@@ -16,7 +16,7 @@ import (
 // RuleInfo contains metadata about a diagnostic rule.
 type RuleInfo struct {
 	Name      string
-	Severity  Severity
+	Severity  string
 	Threshold string
 }
 
@@ -26,67 +26,67 @@ func ListRules() []RuleInfo {
 	return []RuleInfo{
 		{
 			Name:      "disk_io_bottleneck",
-			Severity:  SeverityCritical,
+			Severity:  "WARNING/CRITICAL",
 			Threshold: "fsync p99 > 50ms OR queue > 8",
 		},
 		{
 			Name:      "disk_io_write_high",
-			Severity:  SeverityCritical,
+			Severity:  "CRITICAL",
 			Threshold: "write p99 > 200ms",
 		},
 		{
 			Name:      "oom_kill_occurred",
-			Severity:  SeverityCritical,
+			Severity:  "CRITICAL",
 			Threshold: "OOM kill detected",
 		},
 		{
 			Name:      "tcp_retransmit_storm",
-			Severity:  SeverityCritical,
+			Severity:  "CRITICAL",
 			Threshold: "retransmit rate > 2%",
 		},
 		{
 			Name:      "tcp_rtt_degradation",
-			Severity:  SeverityWarning,
+			Severity:  "WARNING",
 			Threshold: "RTT p99 elevated",
 		},
 		{
 			Name:      "scheduler_contention",
-			Severity:  SeverityCritical,
+			Severity:  "WARNING/CRITICAL",
 			Threshold: "runqueue latency elevated",
 		},
 		{
 			Name:      "fd_leak",
-			Severity:  SeverityWarning,
+			Severity:  "WARNING",
 			Threshold: "FD growth exceeds threshold",
 		},
 		{
 			Name:      "syscall_latency_high",
-			Severity:  SeverityWarning,
+			Severity:  "WARNING/CRITICAL",
 			Threshold: "syscall p99 latency elevated",
 		},
 		{
 			Name:      "oom_imminent",
-			Severity:  SeverityCritical,
+			Severity:  "WARNING/CRITICAL",
 			Threshold: "memory > 90% with positive growth",
 		},
 		{
 			Name:      "syscall_error_rate",
-			Severity:  SeverityWarning,
+			Severity:  "WARNING/CRITICAL",
 			Threshold: "syscall error rate elevated",
 		},
 		{
 			Name:      "memory_limit_pressure",
-			Severity:  SeverityWarning,
+			Severity:  "WARNING/CRITICAL",
 			Threshold: "container nearing memory limit",
 		},
 		{
 			Name:      "memory_high_throttling",
-			Severity:  SeverityWarning,
+			Severity:  "WARNING",
 			Threshold: "memory reclaim pressure detected",
 		},
 		{
 			Name:      "healthy_system",
-			Severity:  SeverityInfo,
+			Severity:  "INFO",
 			Threshold: "no abnormal kernel signals detected",
 		},
 	}

--- a/internal/doctor/rules_test.go
+++ b/internal/doctor/rules_test.go
@@ -4,6 +4,8 @@
 package doctor
 
 import (
+	"os"
+	"regexp"
 	"testing"
 	"time"
 
@@ -746,6 +748,69 @@ func TestFormatBytes(t *testing.T) {
 	for _, c := range cases {
 		if got := formatBytes(c.in); got != c.want {
 			t.Errorf("formatBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestListRules(t *testing.T) {
+	rules := ListRules()
+
+	if len(rules) == 0 {
+		t.Fatal("expected non-empty rule catalog")
+	}
+
+	seen := make(map[string]struct{})
+
+	for _, rule := range rules {
+		if rule.Name == "" {
+			t.Fatal("rule name must not be empty")
+		}
+
+		if _, exists := seen[rule.Name]; exists {
+			t.Fatalf("duplicate rule detected: %s", rule.Name)
+		}
+
+		seen[rule.Name] = struct{}{}
+	}
+}
+
+func TestCatalogParity(t *testing.T) {
+	// 1. Read rules.go
+	content, err := os.ReadFile("rules.go")
+	if err != nil {
+		t.Fatalf("failed to read rules.go: %v", err)
+	}
+
+	// 2. Extract every rule name appearing in literals of the form Rule: "..."
+	re := regexp.MustCompile(`Rule\s*:\s*"([^"]+)"`)
+	matches := re.FindAllStringSubmatch(string(content), -1)
+
+	emittedRules := make(map[string]struct{})
+	for _, match := range matches {
+		if len(match) > 1 {
+			emittedRules[match[1]] = struct{}{}
+		}
+	}
+
+	// 3. Get the catalog rules
+	catalog := ListRules()
+	catalogRules := make(map[string]struct{})
+	for _, rule := range catalog {
+		catalogRules[rule.Name] = struct{}{}
+	}
+
+	// 4. Assert both sets are exactly equal
+	// Check if emitted rules are missing from the catalog
+	for r := range emittedRules {
+		if _, exists := catalogRules[r]; !exists {
+			t.Errorf("Rule %q is emitted in rules.go but is missing from ListRules() catalog", r)
+		}
+	}
+
+	// Check if catalog rules are extra (not emitted in rules.go)
+	for r := range catalogRules {
+		if _, exists := emittedRules[r]; !exists {
+			t.Errorf("Rule %q is present in ListRules() catalog but is not emitted in rules.go", r)
 		}
 	}
 }


### PR DESCRIPTION
## What

Adds a new `kerno doctor --list-rules` flag that prints the full diagnostic rule catalog directly from the CLI and exits immediately without initializing collectors or loading eBPF programs.

## Why

Fixes #10

Users currently have no way to discover which diagnostic rules Kerno evaluates without reading the source code. This exposes the rule catalog in a lightweight and user-friendly way.

## How

* Added a `RuleInfo` metadata structure in `internal/doctor/rules.go`
* Added `ListRules()` exposing all rules that `Evaluate()` may emit
* Added `--list-rules` to `kerno doctor`
* Implemented tab-aligned output using `text/tabwriter`
* Added early short-circuit behavior before collector/eBPF initialization
* Added tests validating:

  * non-empty catalog
  * expected rule count
  * duplicate rule detection

## Testing

* [x] `go build ./...` passes

* [x] `go test ./...` passes

* [ ] `go vet ./...` passes

* [ ] `golangci-lint run ./...` passes

* [x] Tested locally with: `./bin/kerno doctor --list-rules`

* [ ] N/A — pure docs/refactor

* [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load

* [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

* [x] PR title follows Conventional Commits (`feat(cli): add doctor --list-rules flag`)
* [ ] All commits are DCO-signed (`git commit -s`)
* [x] No unrelated changes pulled in
* [x] Documentation updated where user-visible behavior changed
* [x] Added/updated tests for new code paths
* [ ] If a new doctor rule, paired with a chaos scenario in scripts/verify.sh

