### PR TITLE
feat(cli): add -v/--verbose flag for debug-level logging

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -20,6 +20,7 @@ import (
 var (
 	cfgFile string
 	cfg     *config.Config
+	verbose bool
 )
 
 // New creates the root command and registers all sub-commands.
@@ -71,6 +72,7 @@ and copy-paste fix steps.`,
 	pf.String("log-format", "auto", "log encoding: auto (detect TTY), text (human), json (structured)")
 	pf.String("output", "pretty", "output format: pretty (terminal), json (machine)")
 	pf.Bool("no-color", false, "disable colored output (also honors $NO_COLOR)")
+	pf.BoolVarP(&verbose, "verbose", "v", false, "enable verbose (debug-level) logging; shorthand for --log-level=debug")
 
 	// Group sub-commands by purpose so --help reads as a workflow,
 	// not an alphabetic dump.
@@ -157,6 +159,12 @@ func initConfig(cmd *cobra.Command) error {
 
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	// --verbose / -v is a convenience shorthand for --log-level=debug.
+	// It takes highest precedence: overrides config file and --log-level.
+	if verbose {
+		cfg.LogLevel = "debug"
 	}
 
 	// Initialize the global logger.

--- a/internal/cli/root_verbose_test.go
+++ b/internal/cli/root_verbose_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestVerboseFlagRegistered verifies that the --verbose / -v flag is present
+// on the root command with the expected metadata.
+func TestVerboseFlagRegistered(t *testing.T) {
+	root := New()
+
+	f := root.PersistentFlags().Lookup("verbose")
+	if f == nil {
+		t.Fatal("--verbose flag not registered on root command")
+	}
+	if f.Shorthand != "v" {
+		t.Errorf("expected shorthand -v, got %q", f.Shorthand)
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected default false, got %q", f.DefValue)
+	}
+	if f.Value.String() != "false" {
+		t.Errorf("verbose should be false before any flag is set, got %q", f.Value.String())
+	}
+}
+
+// TestVerboseFlagInheritedBySubcommands ensures every subcommand inherits
+// --verbose as a persistent flag from the root, so `kerno doctor -v` works.
+func TestVerboseFlagInheritedBySubcommands(t *testing.T) {
+	root := New()
+
+	subcommands := []string{"doctor", "start", "trace", "watch", "audit", "chaos", "version", "explain"}
+	for _, name := range subcommands {
+		sub := findCmd(root, name)
+		if sub == nil {
+			// Not every build includes every command; skip gracefully.
+			t.Logf("subcommand %q not found, skipping inheritance check", name)
+			continue
+		}
+		if sub.InheritedFlags().Lookup("verbose") == nil {
+			t.Errorf("subcommand %q does not inherit --verbose from root", name)
+		}
+	}
+}
+
+// TestVerboseAndLogLevelAreDistinctFlags ensures --verbose and --log-level
+// remain separate flags and do not shadow each other.
+func TestVerboseAndLogLevelAreDistinctFlags(t *testing.T) {
+	root := New()
+	pf := root.PersistentFlags()
+
+	logLevel := pf.Lookup("log-level")
+	verbose := pf.Lookup("verbose")
+
+	if logLevel == nil {
+		t.Fatal("--log-level flag missing from root")
+	}
+	if verbose == nil {
+		t.Fatal("--verbose flag missing from root")
+	}
+	if logLevel.Name == verbose.Name {
+		t.Error("--log-level and --verbose must be distinct flags")
+	}
+}
+
+// findCmd returns the named direct subcommand of root, or nil if absent.
+func findCmd(root *cobra.Command, name string) *cobra.Command {
+	for _, c := range root.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
adds --verbose / -v as a persistent flag on the root command.
when set it forces log level to debug, overriding both the config file
and --log-level. useful for quick diagnostics without touching config.

changes:
- internal/cli/root.go: registered boolvarp for verbose, wired in
-   initconfig before initlogger so it takes top precedence
- - internal/cli/root_verbose_test.go: 3 tests covering flag registration,
-   -v shorthand, and subcommand inheritance
tested: go test ./internal/cli/...

signed-off-by: abhinavuser <abhinavuser@users.noreply.github.com>