### PR TITLE
feat: add native .deb/.rpm packaging via goreleaser nfpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,104 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  package-install-test:
+    name: Test package install (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # deb targets
+          - distro: ubuntu-22.04
+            image: ubuntu:22.04
+            pkg_type: deb
+          - distro: ubuntu-24.04
+            image: ubuntu:24.04
+            pkg_type: deb
+          - distro: debian-12
+            image: debian:12
+            pkg_type: deb
+          # rpm targets
+          - distro: fedora-39
+            image: fedora:39
+            pkg_type: rpm
+          - distro: al2023
+            image: amazonlinux:2023
+            pkg_type: rpm
+          - distro: rhel-9
+            image: rockylinux:9
+            pkg_type: rpm
+    steps:
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download ${{ github.ref_name }} \
+            --repo ${{ github.repository }} \
+            --pattern "*amd64*.${{ matrix.pkg_type }}" \
+            --dir ./packages
+
+      - name: Test install on ${{ matrix.distro }}
+        run: |
+          PKG=$(ls ./packages/*amd64*.${{ matrix.pkg_type }} | head -1)
+
+          docker run --rm \
+            -v "$(pwd)/packages:/pkgs" \
+            "${{ matrix.image }}" \
+            bash -exc "
+              # ── install the package ──────────────────────────────────────
+              if [ '${{ matrix.pkg_type }}' = 'deb' ]; then
+                apt-get update -q
+                apt-get install -y --no-install-recommends systemd
+                dpkg -i /pkgs/$(basename $PKG) || apt-get install -f -y
+              else
+                dnf install -y systemd /pkgs/$(basename $PKG)
+              fi
+
+              # ── binary exists and is executable ──────────────────────────
+              test -x /usr/local/bin/kerno
+              echo 'PASS: binary present'
+
+              # ── systemd unit is in place ─────────────────────────────────
+              test -f /etc/systemd/system/kerno.service
+              echo 'PASS: systemd unit present'
+
+              # ── config file is in place ──────────────────────────────────
+              test -f /etc/kerno/config.yaml
+              echo 'PASS: config file present'
+
+              # ── system user was created ──────────────────────────────────
+              id kerno
+              echo 'PASS: kerno user exists'
+
+              # ── config is owned by kerno user ────────────────────────────
+              stat -c '%U' /etc/kerno/config.yaml | grep -q kerno
+              echo 'PASS: config ownership correct'
+            "
+
+      - name: Test removal on ${{ matrix.distro }}
+        run: |
+          PKG=$(ls ./packages/*amd64*.${{ matrix.pkg_type }} | head -1)
+          PKG_NAME=$(basename $PKG .${{ matrix.pkg_type }} | sed 's/_[0-9].*//')
+
+          docker run --rm \
+            -v "$(pwd)/packages:/pkgs" \
+            "${{ matrix.image }}" \
+            bash -exc "
+              # install first
+              if [ '${{ matrix.pkg_type }}' = 'deb' ]; then
+                apt-get update -q
+                apt-get install -y --no-install-recommends systemd
+                dpkg -i /pkgs/$(basename $PKG) || apt-get install -f -y
+                dpkg --remove kerno
+              else
+                dnf install -y systemd /pkgs/$(basename $PKG)
+                dnf remove -y kerno
+              fi
+
+              # binary should be gone after removal
+              ! test -f /usr/local/bin/kerno
+              echo 'PASS: binary removed'
+            "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
 
 permissions:
   contents: write
@@ -19,6 +20,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v6
         with:
@@ -56,11 +58,50 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  snapshot:
+    name: Snapshot build (PR)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install BPF toolchain
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            clang llvm libbpf-dev linux-headers-generic
+
+      - name: Run GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload snapshot packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-packages
+          path: |
+            dist/*.deb
+            dist/*.rpm
+          retention-days: 1
 
   package-install-test:
     name: Test package install (${{ matrix.distro }})
     runs-on: ubuntu-latest
-    needs: release
+    needs: [release, snapshot]
+    if: always() && (needs.release.result == 'success' || needs.snapshot.result == 'success')
     strategy:
       fail-fast: false
       matrix:
@@ -86,24 +127,39 @@ jobs:
             image: rockylinux:9
             pkg_type: rpm
     steps:
-      - name: Download release assets
+      - name: Download snapshot packages (PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v4
+        with:
+          name: snapshot-packages
+          path: ./packages
+
+      - name: Download release assets (tag)
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          case "${{ matrix.pkg_type }}" in
+            deb) ARCH=amd64 ;;
+            rpm) ARCH=x86_64 ;;
+          esac
           gh release download ${{ github.ref_name }} \
             --repo ${{ github.repository }} \
-            --pattern "*amd64*.${{ matrix.pkg_type }}" \
+            --pattern "*${ARCH}*.${{ matrix.pkg_type }}" \
             --dir ./packages
 
       - name: Test install on ${{ matrix.distro }}
         run: |
-          PKG=$(ls ./packages/*amd64*.${{ matrix.pkg_type }} | head -1)
+          case "${{ matrix.pkg_type }}" in
+            deb) ARCH=amd64 ;;
+            rpm) ARCH=x86_64 ;;
+          esac
+          PKG=$(ls ./packages/*${ARCH}*.${{ matrix.pkg_type }} | head -1)
 
           docker run --rm \
             -v "$(pwd)/packages:/pkgs" \
             "${{ matrix.image }}" \
             bash -exc "
-              # ── install the package ──────────────────────────────────────
               if [ '${{ matrix.pkg_type }}' = 'deb' ]; then
                 apt-get update -q
                 apt-get install -y --no-install-recommends systemd
@@ -112,37 +168,34 @@ jobs:
                 dnf install -y systemd /pkgs/$(basename $PKG)
               fi
 
-              # ── binary exists and is executable ──────────────────────────
-              test -x /usr/local/bin/kerno
+              test -x /usr/bin/kerno
               echo 'PASS: binary present'
 
-              # ── systemd unit is in place ─────────────────────────────────
               test -f /etc/systemd/system/kerno.service
               echo 'PASS: systemd unit present'
 
-              # ── config file is in place ──────────────────────────────────
               test -f /etc/kerno/config.yaml
               echo 'PASS: config file present'
 
-              # ── system user was created ──────────────────────────────────
               id kerno
               echo 'PASS: kerno user exists'
 
-              # ── config is owned by kerno user ────────────────────────────
               stat -c '%U' /etc/kerno/config.yaml | grep -q kerno
               echo 'PASS: config ownership correct'
             "
 
       - name: Test removal on ${{ matrix.distro }}
         run: |
-          PKG=$(ls ./packages/*amd64*.${{ matrix.pkg_type }} | head -1)
-          PKG_NAME=$(basename $PKG .${{ matrix.pkg_type }} | sed 's/_[0-9].*//')
+          case "${{ matrix.pkg_type }}" in
+            deb) ARCH=amd64 ;;
+            rpm) ARCH=x86_64 ;;
+          esac
+          PKG=$(ls ./packages/*${ARCH}*.${{ matrix.pkg_type }} | head -1)
 
           docker run --rm \
             -v "$(pwd)/packages:/pkgs" \
             "${{ matrix.image }}" \
             bash -exc "
-              # install first
               if [ '${{ matrix.pkg_type }}' = 'deb' ]; then
                 apt-get update -q
                 apt-get install -y --no-install-recommends systemd
@@ -153,7 +206,35 @@ jobs:
                 dnf remove -y kerno
               fi
 
-              # binary should be gone after removal
-              ! test -f /usr/local/bin/kerno
+              ! test -f /usr/bin/kerno
               echo 'PASS: binary removed'
+            "
+
+      - name: Test purge on ${{ matrix.distro }}
+        run: |
+          case "${{ matrix.pkg_type }}" in
+            deb) ARCH=amd64 ;;
+            rpm) ARCH=x86_64 ;;
+          esac
+          PKG=$(ls ./packages/*${ARCH}*.${{ matrix.pkg_type }} | head -1)
+
+          docker run --rm \
+            -v "$(pwd)/packages:/pkgs" \
+            "${{ matrix.image }}" \
+            bash -exc "
+              if [ '${{ matrix.pkg_type }}' = 'deb' ]; then
+                apt-get update -q
+                apt-get install -y --no-install-recommends systemd
+                dpkg -i /pkgs/$(basename $PKG) || apt-get install -f -y
+                dpkg --purge kerno
+              else
+                dnf install -y systemd /pkgs/$(basename $PKG)
+                dnf remove -y kerno
+              fi
+
+              ! test -f /usr/bin/kerno
+              echo 'PASS: binary removed'
+
+              ! test -f /etc/kerno/config.yaml
+              echo 'PASS: config removed'
             "

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,17 +119,23 @@ nfpms:
     vendor: Optiqor
     homepage: https://github.com/optiqor/kerno
     maintainer: Optiqor <team.optiqor@gmail.com>
-    description: |
-      Kerno is a system-level incident 
-      diagnosis engine that explains 
-      production issues across Linux, 
-      Kubernetes, VMs, and bare metal using eBPF. 
+    description: >-
+      Kerno is a system-level incident diagnosis engine that explains production
+      issues across Linux, Kubernetes, VMs, and bare metal using eBPF.
     license: Apache-2.0
     formats:
       - deb
       - rpm
 
-    bindir: /usr/local/bin
+    bindir: /usr/bin
+
+    overrides:
+      deb:
+        dependencies:
+          - systemd
+      rpm:
+        dependencies:
+          - systemd
 
     contents:
       # systemd unit
@@ -137,6 +143,14 @@ nfpms:
         dst: /etc/systemd/system/kerno.service
         file_info:
           mode: 0644
+
+      # license files for deb and rpm
+      - src: LICENSE
+        dst: /usr/share/doc/kerno/copyright
+        packager: deb
+      - src: LICENSE
+        dst: /usr/share/licenses/kerno/LICENSE
+        packager: rpm
 
       # default config — marked as config so apt/dnf never overwrites local edits
       - src: deploy/systemd/kerno.yaml
@@ -148,6 +162,7 @@ nfpms:
           group: kerno
 
     scripts:
+      preinstall: deploy/scripts/preinstall.sh
       postinstall: deploy/scripts/postinstall.sh
       preremove: deploy/scripts/preremove.sh
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,3 +112,51 @@ docker_manifests:
     image_templates:
       - "ghcr.io/optiqor/kerno:{{ .Tag }}-amd64"
       - "ghcr.io/optiqor/kerno:{{ .Tag }}-arm64"
+
+nfpms:
+  - id: kerno-packages
+    package_name: kerno
+    vendor: Optiqor
+    homepage: https://github.com/optiqor/kerno
+    maintainer: Optiqor <team.optiqor@gmail.com>
+    description: |
+      Kerno is a system-level incident 
+      diagnosis engine that explains 
+      production issues across Linux, 
+      Kubernetes, VMs, and bare metal using eBPF. 
+    license: Apache-2.0
+    formats:
+      - deb
+      - rpm
+
+    bindir: /usr/local/bin
+
+    contents:
+      # systemd unit
+      - src: deploy/systemd/kerno.service
+        dst: /etc/systemd/system/kerno.service
+        file_info:
+          mode: 0644
+
+      # default config — marked as config so apt/dnf never overwrites local edits
+      - src: deploy/systemd/kerno.yaml
+        dst: /etc/kerno/config.yaml
+        type: config|noreplace
+        file_info:
+          mode: 0640
+          owner: kerno
+          group: kerno
+
+    scripts:
+      postinstall: deploy/scripts/postinstall.sh
+      preremove: deploy/scripts/preremove.sh
+
+    # RPM-specific metadata
+    rpm:
+      summary: eBPF-powered observability daemon
+      group: System/Daemons
+
+    # deb-specific metadata
+    deb:
+      lintian_overrides:
+        - statically-linked-binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -127,6 +127,12 @@ nfpms:
       - deb
       - rpm
 
+    # Conventional per-format names: deb keeps the Go arch (amd64/arm64),
+    # rpm maps to the rpm arch (x86_64/aarch64). Without this nfpm inherits
+    # the archive name_template and emits *_linux_amd64.rpm, which the
+    # release download patterns and the install matrix never match.
+    file_name_template: "{{ .ConventionalFileName }}"
+
     bindir: /usr/bin
 
     overrides:

--- a/README.md
+++ b/README.md
@@ -140,22 +140,6 @@ ServiceMonitor for the Prometheus Operator is built-in. Raw manifests live at [`
 
 ---
 
-<!-- ### 2 · Bare metal · VMs · EC2 · GCE
-
-The same binary, the same command. No Kubernetes required.
-
-```bash
-curl -sfL https://raw.githubusercontent.com/optiqor/kerno/main/scripts/install.sh | sudo bash
-sudo kerno doctor
-```
-
-Long-lived systemd service with `/metrics` for Prometheus:
-
-```bash
-curl -sfL https://raw.githubusercontent.com/optiqor/kerno/main/scripts/install.sh | sudo bash -s -- --daemon
-journalctl -u kerno -f
-``` -->
-
 
 ### 2 · Bare metal · VMs · EC2 · GCE
 
@@ -175,7 +159,14 @@ curl -LO https://github.com/optiqor/kerno/releases/latest/download/kerno-<versio
 sudo dnf install kerno-<version>.x86_64.rpm
 ```
 
-The package handles everything — binary, systemd unit, config file at `/etc/kerno/config.yaml`, and a locked-down `kerno` system user. Start the daemon:
+Once installed, run:
+
+```bash
+sudo kerno doctor
+```
+
+If you want kerno running persistently as a daemon (for continuous 
+Prometheus metrics):
 
 ```bash
 sudo systemctl enable --now kerno

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ sudo apt install ./kerno_<version>_amd64.deb
 
 On RHEL / Fedora / Amazon Linux 2023:
 ```bash
-curl -LO https://github.com/optiqor/kerno/releases/latest/download/kerno-<version>.x86_64.rpm
-sudo dnf install kerno-<version>.x86_64.rpm
+curl -LO https://github.com/optiqor/kerno/releases/latest/download/kerno-<version>-1.x86_64.rpm
+sudo dnf install kerno-<version>-1.x86_64.rpm
 ```
 
 Once installed, run:

--- a/README.md
+++ b/README.md
@@ -140,9 +140,49 @@ ServiceMonitor for the Prometheus Operator is built-in. Raw manifests live at [`
 
 ---
 
+<!-- ### 2 · Bare metal · VMs · EC2 · GCE
+
+The same binary, the same command. No Kubernetes required.
+
+```bash
+curl -sfL https://raw.githubusercontent.com/optiqor/kerno/main/scripts/install.sh | sudo bash
+sudo kerno doctor
+```
+
+Long-lived systemd service with `/metrics` for Prometheus:
+
+```bash
+curl -sfL https://raw.githubusercontent.com/optiqor/kerno/main/scripts/install.sh | sudo bash -s -- --daemon
+journalctl -u kerno -f
+``` -->
+
+
 ### 2 · Bare metal · VMs · EC2 · GCE
 
 The same binary, the same command. No Kubernetes required.
+
+#### Native package manager (recommended for production)
+
+On Debian/Ubuntu:
+```bash
+curl -LO https://github.com/optiqor/kerno/releases/latest/download/kerno_<version>_amd64.deb
+sudo apt install ./kerno_<version>_amd64.deb
+```
+
+On RHEL / Fedora / Amazon Linux 2023:
+```bash
+curl -LO https://github.com/optiqor/kerno/releases/latest/download/kerno-<version>.x86_64.rpm
+sudo dnf install kerno-<version>.x86_64.rpm
+```
+
+The package handles everything — binary, systemd unit, config file at `/etc/kerno/config.yaml`, and a locked-down `kerno` system user. Start the daemon:
+
+```bash
+sudo systemctl enable --now kerno
+journalctl -u kerno -f
+```
+
+#### curl installer (quick start / CI)
 
 ```bash
 curl -sfL https://raw.githubusercontent.com/optiqor/kerno/main/scripts/install.sh | sudo bash

--- a/deploy/scripts/postinstall.sh
+++ b/deploy/scripts/postinstall.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+# Create a locked-down system user if it doesn't already exist
+if ! id -u kerno &>/dev/null; then
+  useradd -r -s /usr/sbin/nologin -d /nonexistent -c "Kerno daemon" kerno
+fi
+# Ensure the config dir is owned by kerno
+mkdir -p /etc/kerno
+chown kerno:kerno /etc/kerno
+chmod 750 /etc/kerno
+systemctl daemon-reload

--- a/deploy/scripts/postinstall.sh
+++ b/deploy/scripts/postinstall.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
 set -e
-# Create a locked-down system user if it doesn't already exist
-if ! id -u kerno &>/dev/null; then
-  useradd -r -s /usr/sbin/nologin -d /nonexistent -c "Kerno daemon" kerno
-fi
-# Ensure the config dir is owned by kerno
-mkdir -p /etc/kerno
-chown kerno:kerno /etc/kerno
-chmod 750 /etc/kerno
-systemctl daemon-reload
+
+systemctl daemon-reload 2>/dev/null || true

--- a/deploy/scripts/postinstall.sh
+++ b/deploy/scripts/postinstall.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-
 set -e
 
 systemctl daemon-reload 2>/dev/null || true
+
+# On an upgrade, restart only if the unit is already running so the new binary
+# takes effect (preremove leaves it running across upgrades). try-restart is a
+# no-op on a fresh install where the unit was never started.
+systemctl try-restart kerno 2>/dev/null || true

--- a/deploy/scripts/preinstall.sh
+++ b/deploy/scripts/preinstall.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Create group and user before file extraction so ownership is applied correctly
+if ! getent group kerno > /dev/null 2>&1; then
+  groupadd -r kerno
+fi
+if ! id -u kerno > /dev/null 2>&1; then
+  useradd -r -s /usr/sbin/nologin -d /nonexistent -c "Kerno daemon" -g kerno kerno
+fi

--- a/deploy/scripts/preremove.sh
+++ b/deploy/scripts/preremove.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+systemctl stop kerno  || true
+systemctl disable kerno || true

--- a/deploy/scripts/preremove.sh
+++ b/deploy/scripts/preremove.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-
 set -e
-systemctl stop kerno  || true
-systemctl disable kerno || true
+
+# Stop and disable only on a real removal, not during a package upgrade.
+# dpkg passes "remove"/"upgrade" as $1; rpm passes 0 (uninstall) / 1 (upgrade).
+if [ "$1" = "remove" ] || [ "$1" = "0" ]; then
+    systemctl stop kerno || true
+    systemctl disable kerno || true
+fi

--- a/deploy/systemd/kerno.service
+++ b/deploy/systemd/kerno.service
@@ -4,7 +4,7 @@
 # Systemd unit for kerno daemon mode on bare-metal / VMs.
 #
 # Install:
-#   sudo cp kerno /usr/local/bin/kerno
+#   sudo cp kerno /usr/bin/kerno
 #   sudo cp kerno.service /etc/systemd/system/kerno.service
 #   sudo cp kerno.yaml /etc/kerno/config.yaml   (optional)
 #   sudo systemctl daemon-reload
@@ -21,7 +21,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/kerno start
+ExecStart=/usr/bin/kerno start
 Restart=on-failure
 RestartSec=5s
 


### PR DESCRIPTION
## Native `.deb` / `.rpm` packages via goreleaser nfpm

Closes <https://github.com/optiqor/kerno/issues/24>

---

### What this PR does

Adds native Linux package support so kerno can be installed via `apt` and `dnf` on production systems, not just via `curl | bash`.

```bash
# Debian/Ubuntu
sudo apt install ./kerno_0.1.0_amd64.deb

# RHEL / Fedora / Amazon Linux 2023
sudo dnf install kerno-0.1.0.x86_64.rpm
```

---

### Changes

**`.goreleaser.yml`** — adds an `nfpms:` block that produces:
- `kerno_<ver>_amd64.deb`
- `kerno_<ver>_arm64.deb`
- `kerno-<ver>.x86_64.rpm`
- `kerno-<ver>.aarch64.rpm`

Each package installs:
- `/usr/local/bin/kerno` — the binary (picked up automatically from the existing `builds` block)
- `/etc/systemd/system/kerno.service` (`from deploy/systemd/`)
- `/etc/kerno/config.yaml` (from `deploy/systemd/kerno.yaml`), marked `config|noreplace` so `apt upgrade` never overwrites local edits

**`deploy/scripts/postinstall.sh`** — new file, runs after install:
- Creates a locked-down `kerno` system user (`useradd -r -s /usr/sbin/nologin`) if it doesn't already exist
- Sets ownership and permissions on `/etc/kerno`
- Runs `systemctl daemon-reload`

**`deploy/scripts/preremove.sh`** — new file, runs before removal:
- `systemctl stop kerno`
- `systemctl disable kerno`

**`.github/workflows/release.yaml`** — adds a `package-install-test` job that runs after `release`, spinning up Docker containers for each distro and verifying:
- Binary is present and executable
- systemd unit is in place
- `kerno` system user was created
- Clean removal leaves no binary behind

Matrix covers: Ubuntu 22.04, Ubuntu 24.04, Debian 12, Fedora 39, Amazon Linux 2023, Rocky Linux 9 (binary-compatible RHEL 9 substitute — `rhel:9` requires a Red Hat subscription to pull in CI).

**`README.md`** — bare metal install section now documents the native package path above the curl path, since `apt`/`dnf` is the right default for production.

---