### PR TITLE
feat(export): add slack, pagerduty, and discord webhook sinks

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -116,7 +117,7 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
 	flags.StringSliceVar(&sinkURLs, "sink", nil, "webhook sinks (e.g. slack://..., pagerduty://...)")
 	flags.StringVar(&sevFloor, "severity-floor", "warning", "minimum severity to send to sinks (info, warning, critical)")
 	flags.DurationVar(&sinkDedupe, "sink-dedupe", 5*time.Minute, "deduplication window to prevent alert flapping")
-	flags.BoolVar(&dryRunSink, "dry-run-sinks", false, "print payloads instead of sending (useful for debugging sinks)")
+	flags.BoolVar(&dryRunSink, "dry-run-sinks", false, "print finding counts instead of sending (useful for testing sinks)")
 	return cmd
 }
 
@@ -626,27 +627,33 @@ func runDiagnosticCycle(
 		}
 
 		deduped := deduper.Filter(filtered)
+		var wg sync.WaitGroup
 		for _, sink := range activeSinks {
-			var err error
-			if sink.Name() == "pagerduty" {
-				// PagerDuty maintains its own state and needs full list to resolve.
-				if opts.dryRunSinks {
-					logger.Info("dry-run sink (pagerduty)", "findings", len(filtered))
+			wg.Add(1)
+			go func(sink sinks.Sink) {
+				defer wg.Done()
+				var err error
+				if sink.Name() == "pagerduty" {
+					// PagerDuty maintains its own state and needs full list to resolve.
+					if opts.dryRunSinks {
+						logger.Info("dry-run sink (pagerduty)", "findings", len(filtered))
+					} else {
+						err = sink.Send(ctx, filtered)
+					}
 				} else {
-					err = sink.Send(ctx, filtered)
+					// Slack/Discord use deduped list to prevent flapping.
+					if opts.dryRunSinks {
+						logger.Info("dry-run sink", "name", sink.Name(), "findings", len(deduped))
+					} else {
+						err = sink.Send(ctx, deduped)
+					}
 				}
-			} else {
-				// Slack/Discord use deduped list to prevent flapping.
-				if opts.dryRunSinks {
-					logger.Info("dry-run sink", "name", sink.Name(), "findings", len(deduped))
-				} else {
-					err = sink.Send(ctx, deduped)
+				if err != nil {
+					logger.Error("failed to send to sink", "sink", sink.Name(), "error", err)
 				}
-			}
-			if err != nil {
-				logger.Error("failed to send to sink", "sink", sink.Name(), "error", err)
-			}
+			}(sink)
 		}
+		wg.Wait()
 	}
 
 	// Phase 5: Exit code handling for CI/CD.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/optiqor/kerno/internal/collector"
 	"github.com/optiqor/kerno/internal/config"
 	"github.com/optiqor/kerno/internal/doctor"
+	"github.com/optiqor/kerno/internal/sinks"
 )
 
 func newDoctorCmd() *cobra.Command {
@@ -35,6 +36,10 @@ func newDoctorCmd() *cobra.Command {
 		quiet        bool
 		noBanner     bool
 		onlyCritical bool
+		sinkURLs     []string
+		sevFloor     string
+		sinkDedupe   time.Duration
+		dryRunSink   bool
 	)
 
 	cmd := &cobra.Command{
@@ -76,15 +81,19 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
 			}
 
 			return runDoctor(cmd.Context(), doctorOpts{
-				duration:     duration,
-				exitCode:     exitCode,
-				continuous:   continuous,
-				interval:     interval,
-				output:       output,
-				aiEnabled:    aiEnabled,
-				quiet:        quiet,
-				noBanner:     noBanner,
-				onlyCritical: onlyCritical,
+				duration:      duration,
+				exitCode:      exitCode,
+				continuous:    continuous,
+				interval:      interval,
+				output:        output,
+				aiEnabled:     aiEnabled,
+				quiet:         quiet,
+				noBanner:      noBanner,
+				onlyCritical:  onlyCritical,
+				sinkURLs:      sinkURLs,
+				severityFloor: sevFloor,
+				sinkDedupe:    sinkDedupe,
+				dryRunSinks:   dryRunSink,
 			})
 		},
 	}
@@ -104,19 +113,27 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
 	_ = cmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"pretty", "json"}, cobra.ShellCompDirectiveNoFileComp
 	})
+	flags.StringSliceVar(&sinkURLs, "sink", nil, "webhook sinks (e.g. slack://..., pagerduty://...)")
+	flags.StringVar(&sevFloor, "severity-floor", "warning", "minimum severity to send to sinks (info, warning, critical)")
+	flags.DurationVar(&sinkDedupe, "sink-dedupe", 5*time.Minute, "deduplication window to prevent alert flapping")
+	flags.BoolVar(&dryRunSink, "dry-run-sinks", false, "print payloads instead of sending (useful for debugging sinks)")
 	return cmd
 }
 
 type doctorOpts struct {
-	duration     time.Duration
-	exitCode     bool
-	continuous   bool
-	interval     time.Duration
-	output       string
-	aiEnabled    bool
-	quiet        bool
-	noBanner     bool
-	onlyCritical bool
+	duration      time.Duration
+	exitCode      bool
+	continuous    bool
+	interval      time.Duration
+	output        string
+	aiEnabled     bool
+	quiet         bool
+	noBanner      bool
+	onlyCritical  bool
+	sinkURLs      []string
+	severityFloor string
+	sinkDedupe    time.Duration
+	dryRunSinks   bool
 }
 
 func runDoctor(ctx context.Context, opts doctorOpts) error {
@@ -173,6 +190,17 @@ func runDoctor(ctx context.Context, opts doctorOpts) error {
 		}
 	}()
 
+	// Build sinks
+	var activeSinks []sinks.Sink
+	if len(opts.sinkURLs) > 0 {
+		var err error
+		activeSinks, err = sinks.BuildSinks(opts.sinkURLs, logger)
+		if err != nil {
+			return fmt.Errorf("building sinks: %w", err)
+		}
+	}
+	deduper := sinks.NewDeduper(opts.sinkDedupe)
+
 	// Start collectors once for the lifetime of runDoctor.
 	if err := build.registry.StartAll(ctx); err != nil {
 		logger.Warn("one or more collectors failed to start", "error", err)
@@ -181,7 +209,7 @@ func runDoctor(ctx context.Context, opts doctorOpts) error {
 
 	// Run the diagnostic loop (once, or continuous).
 	for {
-		if err := runDiagnosticCycle(ctx, engine, build, renderer, opts, logger); err != nil {
+		if err := runDiagnosticCycle(ctx, engine, build, renderer, opts, activeSinks, deduper, logger); err != nil {
 			return err
 		}
 
@@ -466,6 +494,8 @@ func runDiagnosticCycle(
 	build collectorBuildResult,
 	renderer doctor.Renderer,
 	opts doctorOpts,
+	activeSinks []sinks.Sink,
+	deduper *sinks.Deduper,
 	logger *slog.Logger,
 ) error {
 	registry := build.registry
@@ -571,6 +601,52 @@ func runDiagnosticCycle(
 		}
 	} else if err := renderer.Render(os.Stdout, report); err != nil {
 		return fmt.Errorf("rendering report: %w", err)
+	}
+
+	// Phase 4.5: Sink export
+	if len(activeSinks) > 0 {
+		// Filter by severity floor
+		var minSev doctor.Severity
+		switch strings.ToLower(opts.severityFloor) {
+		case "info":
+			minSev = doctor.SeverityInfo
+		case "warning":
+			minSev = doctor.SeverityWarning
+		case "critical":
+			minSev = doctor.SeverityCritical
+		default:
+			minSev = doctor.SeverityWarning
+		}
+
+		var filtered []doctor.Finding
+		for _, f := range report.Findings {
+			if f.Severity >= minSev {
+				filtered = append(filtered, f)
+			}
+		}
+
+		deduped := deduper.Filter(filtered)
+		for _, sink := range activeSinks {
+			var err error
+			if sink.Name() == "pagerduty" {
+				// PagerDuty maintains its own state and needs full list to resolve.
+				if opts.dryRunSinks {
+					logger.Info("dry-run sink (pagerduty)", "findings", len(filtered))
+				} else {
+					err = sink.Send(ctx, filtered)
+				}
+			} else {
+				// Slack/Discord use deduped list to prevent flapping.
+				if opts.dryRunSinks {
+					logger.Info("dry-run sink", "name", sink.Name(), "findings", len(deduped))
+				} else {
+					err = sink.Send(ctx, deduped)
+				}
+			}
+			if err != nil {
+				logger.Error("failed to send to sink", "sink", sink.Name(), "error", err)
+			}
+		}
 	}
 
 	// Phase 5: Exit code handling for CI/CD.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -155,6 +155,22 @@ var InfoMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Help:      "Kerno build information.",
 }, []string{"version"})
 
+// ─── Sink Metrics ─────────────────────────────────────────────────────────
+
+// SinksDedupedTotal counts findings dropped by the deduplicator.
+var SinksDedupedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: Namespace,
+	Name:      "sinks_deduped_total",
+	Help:      "Total findings dropped by the deduplicator.",
+}, []string{"sink"})
+
+// SinksFailedTotal counts findings that failed to send after retries.
+var SinksFailedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: Namespace,
+	Name:      "sinks_failed_total",
+	Help:      "Total findings that failed to send after retries.",
+}, []string{"sink"})
+
 func init() {
 	Registry.MustRegister(
 		// Syscall
@@ -181,5 +197,8 @@ func init() {
 		CollectorErrorsTotal,
 		BPFProgramsLoaded,
 		InfoMetric,
+		// Sinks
+		SinksDedupedTotal,
+		SinksFailedTotal,
 	)
 }

--- a/internal/sinks/dedupe.go
+++ b/internal/sinks/dedupe.go
@@ -33,7 +33,7 @@ func (d *Deduper) Filter(findings []doctor.Finding) []doctor.Finding {
 	}
 
 	now := time.Now()
-	var novel []doctor.Finding
+	novel := make([]doctor.Finding, 0, len(findings))
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -64,6 +64,6 @@ func (d *Deduper) Filter(findings []doctor.Finding) []doctor.Finding {
 func fingerprint(f doctor.Finding) string {
 	// Include Rule, Severity, and Process.
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("%s:%d:%s", f.Rule, f.Severity, f.Process)))
+	fmt.Fprintf(h, "%s:%d:%s", f.Rule, f.Severity, f.Process)
 	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/internal/sinks/dedupe.go
+++ b/internal/sinks/dedupe.go
@@ -1,0 +1,69 @@
+package sinks
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/optiqor/kerno/internal/doctor"
+	"github.com/optiqor/kerno/internal/metrics"
+)
+
+// Deduper filters out repeated findings to prevent alert fatigue.
+type Deduper struct {
+	ttl   time.Duration
+	mu    sync.RWMutex
+	cache map[string]time.Time
+}
+
+// NewDeduper creates a new Deduper with the given time-to-live.
+func NewDeduper(ttl time.Duration) *Deduper {
+	return &Deduper{
+		ttl:   ttl,
+		cache: make(map[string]time.Time),
+	}
+}
+
+// Filter returns only the findings that are novel (not seen within TTL).
+// It increments the deduplication metric for any dropped findings.
+func (d *Deduper) Filter(findings []doctor.Finding) []doctor.Finding {
+	if d.ttl <= 0 || len(findings) == 0 {
+		return findings
+	}
+
+	now := time.Now()
+	var novel []doctor.Finding
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Clean up stale entries on every filter to prevent unbounded memory growth.
+	// In a high-throughput system, this would be a background goroutine, but
+	// kerno doctor runs relatively infrequently.
+	for k, v := range d.cache {
+		if now.Sub(v) > d.ttl {
+			delete(d.cache, k)
+		}
+	}
+
+	for _, f := range findings {
+		key := fingerprint(f)
+		if lastSeen, exists := d.cache[key]; exists && now.Sub(lastSeen) <= d.ttl {
+			metrics.SinksDedupedTotal.WithLabelValues("all").Inc()
+			continue
+		}
+		d.cache[key] = now
+		novel = append(novel, f)
+	}
+
+	return novel
+}
+
+// fingerprint creates a unique key for deduplication.
+func fingerprint(f doctor.Finding) string {
+	// Include Rule, Severity, and Process.
+	h := sha256.New()
+	h.Write([]byte(fmt.Sprintf("%s:%d:%s", f.Rule, f.Severity, f.Process)))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/internal/sinks/discord.go
+++ b/internal/sinks/discord.go
@@ -19,7 +19,7 @@ func NewDiscordSink(url string, logger *slog.Logger) *DiscordSink {
 	if !strings.HasSuffix(url, "/slack") {
 		url = strings.TrimRight(url, "/") + "/slack"
 	}
-	
+
 	return &DiscordSink{
 		slack: NewSlackSink(url, logger),
 	}

--- a/internal/sinks/discord.go
+++ b/internal/sinks/discord.go
@@ -1,0 +1,33 @@
+package sinks
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/optiqor/kerno/internal/doctor"
+)
+
+// DiscordSink implements Sink for Discord using its built-in Slack compatibility.
+type DiscordSink struct {
+	slack *SlackSink
+}
+
+// NewDiscordSink creates a new DiscordSink.
+func NewDiscordSink(url string, logger *slog.Logger) *DiscordSink {
+	// Discord natively supports Slack payloads if you append /slack to the webhook URL.
+	if !strings.HasSuffix(url, "/slack") {
+		url = strings.TrimRight(url, "/") + "/slack"
+	}
+	
+	return &DiscordSink{
+		slack: NewSlackSink(url, logger),
+	}
+}
+
+func (s *DiscordSink) Name() string { return "discord" }
+
+func (s *DiscordSink) Send(ctx context.Context, findings []doctor.Finding) error {
+	// Delegate to the Slack sink implementation since the endpoint accepts Slack payloads.
+	return s.slack.Send(ctx, findings)
+}

--- a/internal/sinks/pagerduty.go
+++ b/internal/sinks/pagerduty.go
@@ -73,7 +73,7 @@ func (s *PagerDutySink) Send(ctx context.Context, findings []doctor.Finding) err
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("pagerduty sink encountered %d errors, first: %v", len(errs), errs[0])
+		return fmt.Errorf("pagerduty sink encountered %d errors, first: %w", len(errs), errs[0])
 	}
 	return nil
 }

--- a/internal/sinks/pagerduty.go
+++ b/internal/sinks/pagerduty.go
@@ -63,7 +63,7 @@ func (s *PagerDutySink) Send(ctx context.Context, findings []doctor.Finding) err
 		if _, exists := current[key]; !exists {
 			// Create a dummy finding just to hold the key for resolution.
 			// The Events API v2 only strictly needs the routing_key and dedup_key for a resolve.
-			dummy := doctor.Finding{Rule: "cleared"} 
+			dummy := doctor.Finding{Rule: "cleared"}
 			if err := s.sendEvent(ctx, "resolve", key, dummy); err != nil {
 				errs = append(errs, fmt.Errorf("resolving %s: %w", key, err))
 			} else {

--- a/internal/sinks/pagerduty.go
+++ b/internal/sinks/pagerduty.go
@@ -1,0 +1,127 @@
+package sinks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/optiqor/kerno/internal/doctor"
+)
+
+// PagerDutySink implements Sink for PagerDuty Events API v2.
+type PagerDutySink struct {
+	routingKey string
+	logger     *slog.Logger
+	client     *http.Client
+
+	mu     sync.Mutex
+	active map[string]struct{}
+}
+
+// NewPagerDutySink creates a new PagerDutySink.
+func NewPagerDutySink(routingKey string, logger *slog.Logger) *PagerDutySink {
+	return &PagerDutySink{
+		routingKey: routingKey,
+		logger:     logger,
+		client:     &http.Client{Timeout: 10 * time.Second},
+		active:     make(map[string]struct{}),
+	}
+}
+
+func (s *PagerDutySink) Name() string { return "pagerduty" }
+
+// Send delivers findings to PagerDuty. It triggers incidents for active findings
+// and resolves incidents for findings that have cleared since the last cycle.
+func (s *PagerDutySink) Send(ctx context.Context, findings []doctor.Finding) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current := make(map[string]doctor.Finding)
+	for _, f := range findings {
+		key := fingerprint(f)
+		current[key] = f
+	}
+
+	var errs []error
+
+	// Trigger or update currently active findings.
+	for key, f := range current {
+		if err := s.sendEvent(ctx, "trigger", key, f); err != nil {
+			errs = append(errs, fmt.Errorf("triggering %s: %w", key, err))
+		} else {
+			s.active[key] = struct{}{}
+		}
+	}
+
+	// Resolve findings that are no longer present.
+	for key := range s.active {
+		if _, exists := current[key]; !exists {
+			// Create a dummy finding just to hold the key for resolution.
+			// The Events API v2 only strictly needs the routing_key and dedup_key for a resolve.
+			dummy := doctor.Finding{Rule: "cleared"} 
+			if err := s.sendEvent(ctx, "resolve", key, dummy); err != nil {
+				errs = append(errs, fmt.Errorf("resolving %s: %w", key, err))
+			} else {
+				delete(s.active, key)
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("pagerduty sink encountered %d errors, first: %v", len(errs), errs[0])
+	}
+	return nil
+}
+
+func (s *PagerDutySink) sendEvent(ctx context.Context, action, dedupKey string, f doctor.Finding) error {
+	payload := map[string]interface{}{
+		"routing_key":  s.routingKey,
+		"event_action": action,
+		"dedup_key":    dedupKey,
+	}
+
+	if action == "trigger" {
+		severity := "warning"
+		if f.Severity == doctor.SeverityCritical {
+			severity = "critical"
+		} else if f.Severity == doctor.SeverityInfo {
+			severity = "info"
+		}
+
+		payload["payload"] = map[string]interface{}{
+			"summary":  fmt.Sprintf("[%s] %s", f.Severity.String(), f.Title),
+			"source":   "kerno",
+			"severity": severity,
+			"custom_details": map[string]string{
+				"rule":     f.Rule,
+				"process":  f.Process,
+				"signal":   f.Signal,
+				"cause":    f.Cause,
+				"evidence": f.Evidence,
+			},
+		}
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshaling pagerduty payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://events.pagerduty.com/v2/enqueue", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("creating pagerduty request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if err := sendWithRetry(ctx, s.client, req, s.Name()); err != nil {
+		return err
+	}
+
+	s.logger.Debug("sent pagerduty event", "action", action, "dedup_key", dedupKey)
+	return nil
+}

--- a/internal/sinks/sink.go
+++ b/internal/sinks/sink.go
@@ -3,9 +3,9 @@ package sinks
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -87,11 +87,12 @@ func sendWithRetry(ctx context.Context, client *http.Client, req *http.Request, 
 		var bodyCopy []byte
 		if req.Body != nil {
 			var err error
-			bodyCopy, err = readAllAndClose(req.Body)
+			bodyCopy, err = io.ReadAll(req.Body)
+			req.Body.Close()
 			if err != nil {
 				return fmt.Errorf("reading request body: %w", err)
 			}
-			req.Body = ioNopCloser(bytes.NewReader(bodyCopy))
+			req.Body = io.NopCloser(bytes.NewReader(bodyCopy))
 		}
 
 		resp, err := client.Do(req)
@@ -118,30 +119,11 @@ func sendWithRetry(ctx context.Context, client *http.Client, req *http.Request, 
 			}
 			// Restore body for the next attempt
 			if bodyCopy != nil {
-				req.Body = ioNopCloser(bytes.NewReader(bodyCopy))
+				req.Body = io.NopCloser(bytes.NewReader(bodyCopy))
 			}
 		}
 	}
 
 	metrics.SinksFailedTotal.WithLabelValues(sinkName).Inc()
 	return fmt.Errorf("failed after %d attempts: %w", maxRetries, lastErr)
-}
-
-// Helper to read and close body
-func readAllAndClose(rc interface{ Read(p []byte) (n int, err error); Close() error }) ([]byte, error) {
-	defer rc.Close()
-	buf := new(bytes.Buffer)
-	_, err := buf.ReadFrom(rc)
-	return buf.Bytes(), err
-}
-
-// Helper to create a ReadCloser
-type nopCloser struct {
-	*bytes.Reader
-}
-
-func (nopCloser) Close() error { return nil }
-
-func ioNopCloser(r *bytes.Reader) interface{ Read(p []byte) (n int, err error); Close() error } {
-	return nopCloser{r}
 }

--- a/internal/sinks/sink.go
+++ b/internal/sinks/sink.go
@@ -70,9 +70,7 @@ func BuildSinks(urls []string, logger *slog.Logger) ([]Sink, error) {
 // expandEnvInURL allows users to pass "slack://$KERNO_SLACK_WEBHOOK_URL"
 // to avoid putting secrets in shell history.
 func expandEnvInURL(u string) string {
-	return os.Expand(u, func(key string) string {
-		return os.Getenv(key)
-	})
+	return os.Expand(u, os.Getenv)
 }
 
 // sendWithRetry executes an HTTP request with exponential backoff.

--- a/internal/sinks/sink.go
+++ b/internal/sinks/sink.go
@@ -1,0 +1,147 @@
+package sinks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/optiqor/kerno/internal/doctor"
+	"github.com/optiqor/kerno/internal/metrics"
+)
+
+// Sink represents a destination for doctor findings.
+type Sink interface {
+	// Name returns the identifier of the sink (e.g., "slack", "pagerduty").
+	Name() string
+	// Send delivers the findings to the destination. It may be called concurrently.
+	Send(ctx context.Context, findings []doctor.Finding) error
+}
+
+// BuildSinks parses sink URLs and returns a list of configured Sinks.
+// It resolves environment variable references (e.g., slack://$KERNO_SLACK_WEBHOOK_URL).
+func BuildSinks(urls []string, logger *slog.Logger) ([]Sink, error) {
+	var sinks []Sink
+	for _, rawURL := range urls {
+		u := expandEnvInURL(rawURL)
+
+		switch {
+		case strings.HasPrefix(u, "slack://"):
+			webhookURL := strings.TrimPrefix(u, "slack://")
+			if webhookURL == "" {
+				return nil, errors.New("slack sink requires a webhook URL")
+			}
+			// Re-add https if they stripped it in the slack:// prefix, assuming https:// for hooks.
+			if !strings.HasPrefix(webhookURL, "http") {
+				webhookURL = "https://" + webhookURL
+			}
+			sinks = append(sinks, NewSlackSink(webhookURL, logger))
+
+		case strings.HasPrefix(u, "pagerduty://"):
+			routingKey := strings.TrimPrefix(u, "pagerduty://")
+			if routingKey == "" {
+				return nil, errors.New("pagerduty sink requires a routing key")
+			}
+			sinks = append(sinks, NewPagerDutySink(routingKey, logger))
+
+		case strings.HasPrefix(u, "discord://"):
+			webhookURL := strings.TrimPrefix(u, "discord://")
+			if webhookURL == "" {
+				return nil, errors.New("discord sink requires a webhook URL")
+			}
+			if !strings.HasPrefix(webhookURL, "http") {
+				webhookURL = "https://" + webhookURL
+			}
+			sinks = append(sinks, NewDiscordSink(webhookURL, logger))
+
+		default:
+			return nil, fmt.Errorf("unsupported sink type: %s", rawURL)
+		}
+	}
+	return sinks, nil
+}
+
+// expandEnvInURL allows users to pass "slack://$KERNO_SLACK_WEBHOOK_URL"
+// to avoid putting secrets in shell history.
+func expandEnvInURL(u string) string {
+	return os.Expand(u, func(key string) string {
+		return os.Getenv(key)
+	})
+}
+
+// sendWithRetry executes an HTTP request with exponential backoff.
+// Max 3 attempts.
+func sendWithRetry(ctx context.Context, client *http.Client, req *http.Request, sinkName string) error {
+	const maxRetries = 3
+	baseDelay := 1 * time.Second
+
+	var lastErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		// We must clone the request body for retries
+		var bodyCopy []byte
+		if req.Body != nil {
+			var err error
+			bodyCopy, err = readAllAndClose(req.Body)
+			if err != nil {
+				return fmt.Errorf("reading request body: %w", err)
+			}
+			req.Body = ioNopCloser(bytes.NewReader(bodyCopy))
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+		} else {
+			resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+			lastErr = fmt.Errorf("HTTP %d", resp.StatusCode)
+			if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != 429 {
+				// Client error (not rate limit) - don't retry.
+				metrics.SinksFailedTotal.WithLabelValues(sinkName).Inc()
+				return lastErr
+			}
+		}
+
+		if attempt < maxRetries-1 {
+			select {
+			case <-time.After(baseDelay * time.Duration(1<<attempt)):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			// Restore body for the next attempt
+			if bodyCopy != nil {
+				req.Body = ioNopCloser(bytes.NewReader(bodyCopy))
+			}
+		}
+	}
+
+	metrics.SinksFailedTotal.WithLabelValues(sinkName).Inc()
+	return fmt.Errorf("failed after %d attempts: %w", maxRetries, lastErr)
+}
+
+// Helper to read and close body
+func readAllAndClose(rc interface{ Read(p []byte) (n int, err error); Close() error }) ([]byte, error) {
+	defer rc.Close()
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(rc)
+	return buf.Bytes(), err
+}
+
+// Helper to create a ReadCloser
+type nopCloser struct {
+	*bytes.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+func ioNopCloser(r *bytes.Reader) interface{ Read(p []byte) (n int, err error); Close() error } {
+	return nopCloser{r}
+}

--- a/internal/sinks/sinks_test.go
+++ b/internal/sinks/sinks_test.go
@@ -104,7 +104,7 @@ func TestPagerDutySink(t *testing.T) {
 	}
 
 	f1 := doctor.Finding{Rule: "rule1", Severity: doctor.SeverityWarning}
-	
+
 	// Cycle 1: trigger
 	err := sink.Send(context.Background(), []doctor.Finding{f1})
 	if err != nil {

--- a/internal/sinks/sinks_test.go
+++ b/internal/sinks/sinks_test.go
@@ -77,7 +77,7 @@ func TestSlackSink(t *testing.T) {
 	if !ok || len(attachments) != 1 {
 		t.Fatalf("expected 1 attachment, got %v", attachments)
 	}
-	
+
 	att := attachments[0].(map[string]interface{})
 	if att["color"] != "#e01e5a" {
 		t.Errorf("expected critical color #e01e5a, got %v", att["color"])

--- a/internal/sinks/sinks_test.go
+++ b/internal/sinks/sinks_test.go
@@ -1,0 +1,176 @@
+package sinks
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/optiqor/kerno/internal/doctor"
+)
+
+func TestDeduper(t *testing.T) {
+	d := NewDeduper(50 * time.Millisecond)
+
+	f1 := doctor.Finding{Rule: "A", Severity: doctor.SeverityWarning, Process: "foo"}
+	f2 := doctor.Finding{Rule: "B", Severity: doctor.SeverityCritical, Process: "bar"}
+
+	// First pass: both novel
+	novel := d.Filter([]doctor.Finding{f1, f2})
+	if len(novel) != 2 {
+		t.Fatalf("expected 2 novel findings, got %d", len(novel))
+	}
+
+	// Second pass immediately: both dropped
+	novel = d.Filter([]doctor.Finding{f1, f2})
+	if len(novel) != 0 {
+		t.Fatalf("expected 0 novel findings (deduped), got %d", len(novel))
+	}
+
+	// Wait for TTL
+	time.Sleep(60 * time.Millisecond)
+
+	// Third pass: both novel again
+	novel = d.Filter([]doctor.Finding{f1, f2})
+	if len(novel) != 2 {
+		t.Fatalf("expected 2 novel findings after TTL, got %d", len(novel))
+	}
+}
+
+func TestSlackSink(t *testing.T) {
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := NewSlackSink(srv.URL, slog.Default())
+	findings := []doctor.Finding{
+		{
+			Title:    "OOM Kill",
+			Rule:     "oom",
+			Severity: doctor.SeverityCritical,
+			Process:  "postgres",
+			Cause:    "out of memory",
+			Impact:   "process killed",
+			Fix:      []string{"increase limit"},
+		},
+	}
+
+	err := sink.Send(context.Background(), findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if body["text"] != "Kerno Diagnostic Findings" {
+		t.Errorf("unexpected text in payload: %v", body["text"])
+	}
+
+	attachments, ok := body["attachments"].([]interface{})
+	if !ok || len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %v", attachments)
+	}
+	
+	att := attachments[0].(map[string]interface{})
+	if att["color"] != "#e01e5a" {
+		t.Errorf("expected critical color #e01e5a, got %v", att["color"])
+	}
+}
+
+func TestPagerDutySink(t *testing.T) {
+	var actions []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&payload)
+		actions = append(actions, payload["event_action"].(string))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	sink := NewPagerDutySink("dummy-key", slog.Default())
+	sink.client.Transport = srv.Client().Transport // use same transport
+
+	// We override the URL in the sink to point to our test server
+	// Note: since the URL is hardcoded in pagerduty.go, we would normally make it configurable.
+	// For this test, we'll just test the Send loop with a mocked http.Client or RoundTripper.
+	
+	// Let's mock the RoundTripper to intercept the hardcoded URL.
+	sink.client.Transport = &mockTransport{
+		fn: func(req *http.Request) (*http.Response, error) {
+			var payload map[string]interface{}
+			json.NewDecoder(req.Body).Decode(&payload)
+			actions = append(actions, payload["event_action"].(string))
+			return &http.Response{StatusCode: 202, Body: nopCloser{}}, nil
+		},
+	}
+
+	f1 := doctor.Finding{Rule: "rule1", Severity: doctor.SeverityWarning}
+	
+	// Cycle 1: trigger
+	err := sink.Send(context.Background(), []doctor.Finding{f1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(actions) != 1 || actions[0] != "trigger" {
+		t.Fatalf("expected 1 trigger, got %v", actions)
+	}
+
+	// Cycle 2: same finding, should trigger again (PD natively dedups triggers)
+	actions = nil
+	err = sink.Send(context.Background(), []doctor.Finding{f1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(actions) != 1 || actions[0] != "trigger" {
+		t.Fatalf("expected 1 trigger, got %v", actions)
+	}
+
+	// Cycle 3: finding clears (empty list) -> should resolve
+	actions = nil
+	err = sink.Send(context.Background(), []doctor.Finding{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(actions) != 1 || actions[0] != "resolve" {
+		t.Fatalf("expected 1 resolve, got %v", actions)
+	}
+}
+
+func TestRetryBackoff(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL, nil)
+	err := sendWithRetry(context.Background(), srv.Client(), req, "test")
+
+	if err == nil {
+		t.Fatal("expected error after retries, got nil")
+	}
+
+	if atomic.LoadInt32(&calls) != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+type nopCloser struct{}
+
+func (nopCloser) Read(p []byte) (n int, err error) { return 0, nil }
+func (nopCloser) Close() error                     { return nil }
+
+type mockTransport struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.fn(req)
+}

--- a/internal/sinks/sinks_test.go
+++ b/internal/sinks/sinks_test.go
@@ -1,8 +1,10 @@
 package sinks
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -84,16 +86,8 @@ func TestSlackSink(t *testing.T) {
 
 func TestPagerDutySink(t *testing.T) {
 	var actions []string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var payload map[string]interface{}
-		json.NewDecoder(r.Body).Decode(&payload)
-		actions = append(actions, payload["event_action"].(string))
-		w.WriteHeader(http.StatusAccepted)
-	}))
-	defer srv.Close()
 
 	sink := NewPagerDutySink("dummy-key", slog.Default())
-	sink.client.Transport = srv.Client().Transport // use same transport
 
 	// We override the URL in the sink to point to our test server
 	// Note: since the URL is hardcoded in pagerduty.go, we would normally make it configurable.
@@ -105,7 +99,7 @@ func TestPagerDutySink(t *testing.T) {
 			var payload map[string]interface{}
 			json.NewDecoder(req.Body).Decode(&payload)
 			actions = append(actions, payload["event_action"].(string))
-			return &http.Response{StatusCode: 202, Body: nopCloser{}}, nil
+			return &http.Response{StatusCode: 202, Body: io.NopCloser(bytes.NewReader(nil))}, nil
 		},
 	}
 
@@ -161,11 +155,6 @@ func TestRetryBackoff(t *testing.T) {
 		t.Errorf("expected 3 calls, got %d", calls)
 	}
 }
-
-type nopCloser struct{}
-
-func (nopCloser) Read(p []byte) (n int, err error) { return 0, nil }
-func (nopCloser) Close() error                     { return nil }
 
 type mockTransport struct {
 	fn func(*http.Request) (*http.Response, error)

--- a/internal/sinks/sinks_test.go
+++ b/internal/sinks/sinks_test.go
@@ -92,7 +92,7 @@ func TestPagerDutySink(t *testing.T) {
 	// We override the URL in the sink to point to our test server
 	// Note: since the URL is hardcoded in pagerduty.go, we would normally make it configurable.
 	// For this test, we'll just test the Send loop with a mocked http.Client or RoundTripper.
-	
+
 	// Let's mock the RoundTripper to intercept the hardcoded URL.
 	sink.client.Transport = &mockTransport{
 		fn: func(req *http.Request) (*http.Response, error) {

--- a/internal/sinks/slack.go
+++ b/internal/sinks/slack.go
@@ -56,7 +56,7 @@ func (s *SlackSink) Send(ctx context.Context, findings []doctor.Finding) error {
 }
 
 func (s *SlackSink) buildPayload(findings []doctor.Finding) map[string]interface{} {
-	var attachments []map[string]interface{}
+	attachments := make([]map[string]interface{}, 0, len(findings))
 
 	for _, f := range findings {
 		color := "#f2c744" // yellow for WARNING

--- a/internal/sinks/slack.go
+++ b/internal/sinks/slack.go
@@ -1,0 +1,128 @@
+package sinks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/optiqor/kerno/internal/doctor"
+)
+
+// SlackSink implements Sink for Slack Incoming Webhooks using Block Kit.
+type SlackSink struct {
+	url    string
+	logger *slog.Logger
+	client *http.Client
+}
+
+// NewSlackSink creates a new SlackSink.
+func NewSlackSink(url string, logger *slog.Logger) *SlackSink {
+	return &SlackSink{
+		url:    url,
+		logger: logger,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (s *SlackSink) Name() string { return "slack" }
+
+func (s *SlackSink) Send(ctx context.Context, findings []doctor.Finding) error {
+	if len(findings) == 0 {
+		return nil
+	}
+
+	payload := s.buildPayload(findings)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshaling slack payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("creating slack request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if err := sendWithRetry(ctx, s.client, req, s.Name()); err != nil {
+		return fmt.Errorf("slack sink failed: %w", err)
+	}
+
+	s.logger.Debug("sent findings to slack", "count", len(findings))
+	return nil
+}
+
+func (s *SlackSink) buildPayload(findings []doctor.Finding) map[string]interface{} {
+	var attachments []map[string]interface{}
+
+	for _, f := range findings {
+		color := "#f2c744" // yellow for WARNING
+		if f.Severity == doctor.SeverityCritical {
+			color = "#e01e5a" // red for CRITICAL
+		}
+
+		blocks := []map[string]interface{}{
+			{
+				"type": "header",
+				"text": map[string]interface{}{
+					"type": "plain_text",
+					"text": fmt.Sprintf("[%s] %s", f.Severity.String(), f.Title),
+				},
+			},
+			{
+				"type": "section",
+				"text": map[string]interface{}{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("*Cause:*\n%s\n\n*Impact:*\n%s", f.Cause, f.Impact),
+				},
+			},
+		}
+
+		if f.Process != "" {
+			blocks = append(blocks, map[string]interface{}{
+				"type": "section",
+				"text": map[string]interface{}{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("*Process:* `%s` | *Signal:* `%s`", f.Process, f.Signal),
+				},
+			})
+		}
+
+		if f.Evidence != "" {
+			blocks = append(blocks, map[string]interface{}{
+				"type": "section",
+				"text": map[string]interface{}{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("*Evidence:*\n```%s```", f.Evidence),
+				},
+			})
+		}
+
+		if len(f.Fix) > 0 {
+			var fixText string
+			for _, fix := range f.Fix {
+				fixText += fmt.Sprintf("• %s\n", fix)
+			}
+			blocks = append(blocks, map[string]interface{}{
+				"type": "section",
+				"text": map[string]interface{}{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("*Fix:*\n%s", fixText),
+				},
+			})
+		}
+
+		attachments = append(attachments, map[string]interface{}{
+			"color":  color,
+			"blocks": blocks,
+		})
+	}
+
+	return map[string]interface{}{
+		"text":        "Kerno Diagnostic Findings",
+		"attachments": attachments,
+	}
+}


### PR DESCRIPTION
fixes #29

added built-in webhook sinks for `kerno doctor` findings. wired up the `--sink`, `--severity-floor`, and `--sink-dedupe` flags.
what's included:
- `Sink` interface with exponential backoff retries on 5xx errors
- in-memory deduplicator to prevent flapping rules from spamming on-call
- slack integration using block kit format for clean readability
- pagerduty integration via events api v2. handles trigger events and automatically sends a resolve event when a finding clears in continuous mode
- discord integration utilizing discord's native slack-compat url suffix
- `kerno_sinks_deduped_total` and `kerno_sinks_failed_total` metrics
- full test suite using `httptest.Server`
all env vars like `KERNO_SLACK_WEBHOOK_URL` are expanded automatically if passed as flag values to keep shell history clean.

Signed-off-by: abhinavuser <abhinavkumarv2101@gmail.com>