### PR TITLE
docs: improve onboarding for the two build modes (closes #61)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,17 +41,24 @@ git commit -s -m "feat: add syscall latency collector"
 
 ### System Requirements
 
+**Required (for basic Go development):**
+
 | Requirement | Minimum | Recommended | Notes |
 |---|---|---|---|
-| **Linux kernel** | 5.8 | 6.1+ | Must have `CONFIG_DEBUG_INFO_BTF=y` |
 | **Go** | 1.24 | 1.25+ | [install](https://go.dev/doc/install) |
+| **make** | 4.0 | - | Build orchestration |
+
+**Optional (for eBPF development and running Kerno):**
+
+| Requirement | Minimum | Recommended | Notes |
+|---|---|---|---|
+| **Linux kernel** | 5.8 | 6.1+ | Must have `CONFIG_DEBUG_INFO_BTF=y` to run |
 | **clang** | 14 | 17+ | For eBPF C compilation |
 | **llvm** | 14 | 17+ | `llvm-strip` used by bpf2go |
 | **libbpf-dev** | 0.8 | 1.0+ | BPF CO-RE headers |
 | **bpftool** | - | latest | BTF inspection and debugging |
-| **make** | 4.0 | - | Build orchestration |
 
-### Step 1 - Install System Dependencies
+### Step 1 - Install System Dependencies (Optional for Go-only dev)
 
 **Ubuntu / Debian (22.04+):**
 
@@ -132,21 +139,11 @@ go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 go install github.com/goreleaser/goreleaser/v2@latest
 ```
 
-### Step 4 - Verify BTF Support
+### Step 4 - Clone and Build
 
-Kerno requires BTF (BPF Type Format) in your kernel:
-
-```bash
-# Check if BTF is available
-ls /sys/kernel/btf/vmlinux && echo "BTF: OK" || echo "BTF: MISSING"
-
-# Alternative check
-bpftool btf dump file /sys/kernel/btf/vmlinux format raw | head -c 4
-```
-
-If BTF is missing, you need a kernel compiled with `CONFIG_DEBUG_INFO_BTF=y`. Most modern distro kernels (Ubuntu 22.04+, Fedora 38+, Arch) have this enabled by default.
-
-### Step 5 - Clone and Build
+Kerno supports two build modes depending on what you are working on:
+- **Go-only mode (`make build`)**: Uses pre-generated Go stub types so you can develop and test Go code without clang/libbpf installed.
+- **eBPF mode (`make build-ebpf`)**: Compiles eBPF C programs and generates bindings. Requires all system dependencies installed.
 
 ```bash
 git clone https://github.com/optiqor/kerno.git
@@ -160,7 +157,7 @@ make build
 ./bin/kerno --help
 ```
 
-### Step 6 - Full Build with eBPF Compilation (Optional)
+### Step 5 - Full Build with eBPF Compilation (Optional)
 
 If you're working on the eBPF C programs:
 
@@ -176,6 +173,20 @@ make generate
 ```
 
 > **Note:** The standard `make build` uses pre-generated Go stub types (`gen_stub.go`) so you can develop and test Go code without clang/libbpf installed. Only use `make build-ebpf` when modifying the eBPF C programs.
+
+### Step 6 - Verify BTF Support
+
+Kerno requires BTF (BPF Type Format) in your kernel to run eBPF programs:
+
+```bash
+# Check if BTF is available
+ls /sys/kernel/btf/vmlinux && echo "BTF: OK" || echo "BTF: MISSING"
+
+# Alternative check
+bpftool btf dump file /sys/kernel/btf/vmlinux format raw | head -c 4
+```
+
+If BTF is missing, you need a kernel compiled with `CONFIG_DEBUG_INFO_BTF=y`. Most modern distro kernels (Ubuntu 22.04+, Fedora 38+, Arch) have this enabled by default.
 
 ### Step 7 - Run the Doctor (requires root)
 
@@ -328,7 +339,7 @@ kerno/
 ### Key Architecture Decisions
 
 - **`internal/`** - All packages are internal; the only public API is the CLI binary.
-- **Build tag strategy** - `gen_stub.go` (`//go:build !ebpf`) provides stub types so `make build` works without clang. The real BPF-generated types are only produced when running `make generate` with the `ebpf` build tag.
+- **Build tag strategy** - `gen_stub.go` (`//go:build !ebpf`) provides stub types so `make build` works without clang. `make generate` post-processes the BPF-generated types to require the `ebpf` build tag, making stubs and generated files mutually exclusive.
 - **Loader interface** - Each eBPF program has a typed Go loader implementing a common `Loader` interface, enabling uniform lifecycle management via `LoaderSet`.
 - **Collector interface** - Collectors consume raw events from loaders, aggregate them into typed snapshots, and expose them via a `Registry` for the doctor engine.
 


### PR DESCRIPTION
## What
Splits the system dependencies in CONTRIBUTING.md to clearly distinguish between basic Go-only requirements and eBPF requirements. It also clarifies the two build modes and updates the documentation to reflect the current gen_stub.go build tag strategy.

## Why
Fixes #61 

## How

* Split the System Requirements table into Required (Go, make) and Optional (clang, libbpf-dev, etc.).
* Marked Step 1 (Install System Dependencies) as optional for Go-only contributors.
* Moved the BTF verification step down, as it is only needed when running eBPF programs, not for building Go code.
* Added explicit instructions detailing the difference between make build and make build-ebpf.
* Updated the Build tag strategy section to accurately reflect that make generate now post-processes generated files to require the ebpf tag, making stubs and generated files mutually exclusive.

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Tested locally with: `make check`

<!-- Required for changes touching internal/bpf/, internal/collector/, internal/doctor/. -->

- [x] N/A — pure docs/refactor
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed
- [ ] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`
