### PR TITLE
feat(cli): implement only-critical flag

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -25,15 +25,16 @@ import (
 
 func newDoctorCmd() *cobra.Command {
 	var (
-		duration   time.Duration
-		exitCode   bool
-		continuous bool
-		interval   time.Duration
-		output     string
-		useAI      bool
-		noAI       bool
-		quiet      bool
-		noBanner   bool
+		duration     time.Duration
+		exitCode     bool
+		continuous   bool
+		interval     time.Duration
+		output       string
+		useAI        bool
+		noAI         bool
+		quiet        bool
+		noBanner     bool
+		onlyCritical bool
 	)
 
 	cmd := &cobra.Command{
@@ -75,14 +76,15 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
 			}
 
 			return runDoctor(cmd.Context(), doctorOpts{
-				duration:   duration,
-				exitCode:   exitCode,
-				continuous: continuous,
-				interval:   interval,
-				output:     output,
-				aiEnabled:  aiEnabled,
-				quiet:      quiet,
-				noBanner:   noBanner,
+				duration:     duration,
+				exitCode:     exitCode,
+				continuous:   continuous,
+				interval:     interval,
+				output:       output,
+				aiEnabled:    aiEnabled,
+				quiet:        quiet,
+				noBanner:     noBanner,
+				onlyCritical: onlyCritical,
 			})
 		},
 	}
@@ -97,24 +99,24 @@ Add --ai to enrich findings with AI-powered analysis (requires API key).`,
 	flags.BoolVar(&noAI, "no-ai", false, "disable AI analysis even if enabled in config")
 	flags.BoolVarP(&quiet, "quiet", "q", false, "only emit critical/warning findings (CI-friendly)")
 	flags.BoolVar(&noBanner, "no-banner", false, "suppress the ASCII banner block")
-
+	flags.BoolVar(&onlyCritical, "only-critical", false, "show only critical severity items")
 	//nolint:errcheck // RegisterFlagCompletionFunc only returns error on invalid flag name, which is static.
 	_ = cmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"pretty", "json"}, cobra.ShellCompDirectiveNoFileComp
 	})
-
 	return cmd
 }
 
 type doctorOpts struct {
-	duration   time.Duration
-	exitCode   bool
-	continuous bool
-	interval   time.Duration
-	output     string
-	aiEnabled  bool
-	quiet      bool
-	noBanner   bool
+	duration     time.Duration
+	exitCode     bool
+	continuous   bool
+	interval     time.Duration
+	output       string
+	aiEnabled    bool
+	quiet        bool
+	noBanner     bool
+	onlyCritical bool
 }
 
 func runDoctor(ctx context.Context, opts doctorOpts) error {
@@ -542,6 +544,12 @@ func runDiagnosticCycle(
 	report.LoadFailures = build.failures
 	report.ProgramsLoaded = build.loaded
 
+	// phase 3b: apply only-critical filter
+	// happens after rule evaluation but before rendering.
+	if opts.onlyCritical {
+		report.Findings = doctor.FilterCriticalFindings(report.Findings)
+	}
+
 	// Phase 4: Render the report.
 	//
 	// In --quiet mode, we suppress the full pretty rendering when the
@@ -568,6 +576,7 @@ func runDiagnosticCycle(
 	}
 
 	// Phase 5: Exit code handling for CI/CD.
+	// with only-critical, only exit 1 if critical items remain after filtering
 	if opts.exitCode && report.HasCritical() {
 		return &exitError{code: 1}
 	}

--- a/internal/doctor/engine.go
+++ b/internal/doctor/engine.go
@@ -170,3 +170,20 @@ func hasActionableFindings(findings []Finding) bool {
 	}
 	return false
 }
+
+// FilterCriticalFindings returns only critical severity findings from the list
+func FilterCriticalFindings(findings []Finding) []Finding {
+	if len(findings) == 0 {
+		return []Finding{}
+	}
+	filtered := make([]Finding, 0, len(findings))
+	for i := range findings {
+		if findings[i].Severity == SeverityCritical {
+			filtered = append(filtered, findings[i])
+		}
+	}
+	if len(filtered) == 0 {
+		return []Finding{}
+	}
+	return filtered
+}

--- a/internal/doctor/engine.go
+++ b/internal/doctor/engine.go
@@ -173,17 +173,11 @@ func hasActionableFindings(findings []Finding) bool {
 
 // FilterCriticalFindings returns only critical severity findings from the list
 func FilterCriticalFindings(findings []Finding) []Finding {
-	if len(findings) == 0 {
-		return []Finding{}
-	}
 	filtered := make([]Finding, 0, len(findings))
 	for i := range findings {
 		if findings[i].Severity == SeverityCritical {
 			filtered = append(filtered, findings[i])
 		}
-	}
-	if len(filtered) == 0 {
-		return []Finding{}
 	}
 	return filtered
 }

--- a/internal/doctor/finding_test.go
+++ b/internal/doctor/finding_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Optiqor contributors
+// SDPX-License-Identifier: Apache-2.0
+
+package doctor
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFilterCriticalFindings_Basic(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []Finding
+		wantLen     int
+		wantAllCrit bool
+	}{
+		{
+			name:        "nil input",
+			input:       nil,
+			wantLen:     0,
+			wantAllCrit: true,
+		},
+		{
+			name:        "empty slice",
+			input:       []Finding{},
+			wantLen:     0,
+			wantAllCrit: true,
+		},
+		{
+			name: "all critical",
+			input: []Finding{
+				{Severity: SeverityCritical, Title: "C1"},
+				{Severity: SeverityCritical, Title: "C2"},
+			},
+			wantLen:     2,
+			wantAllCrit: true,
+		},
+		{
+			name: "mixed severities",
+			input: []Finding{
+				{Severity: SeverityCritical, Title: "Critical"},
+				{Severity: SeverityWarning, Title: "Warning"},
+				{Severity: SeverityInfo, Title: "Info"},
+				{Severity: SeverityCritical, Title: "Critical2"},
+			},
+			wantLen:     2,
+			wantAllCrit: true,
+		},
+		{
+			name: "no critical",
+			input: []Finding{
+				{Severity: SeverityWarning, Title: "W1"},
+				{Severity: SeverityWarning, Title: "W2"},
+				{Severity: SeverityInfo, Title: "I1"},
+			},
+			wantLen:     0,
+			wantAllCrit: true,
+		},
+		{
+			name: "single critical",
+			input: []Finding{
+				{Severity: SeverityInfo, Title: "Info"},
+				{Severity: SeverityCritical, Title: "Crit"},
+				{Severity: SeverityWarning, Title: "Warn"},
+			},
+			wantLen:     1,
+			wantAllCrit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterCriticalFindings(tt.input)
+			if len(got) != tt.wantLen {
+				t.Errorf("len(got)=%d, want %d", len(got), tt.wantLen)
+			}
+			if tt.wantAllCrit {
+				for i, f := range got {
+					if f.Severity != SeverityCritical {
+						t.Errorf("got[%d].Severity=%v, want CRITICAL", i, f.Severity)
+					}
+				}
+			}
+
+			if len(got) == 0 && got == nil {
+				t.Error("got nil for empty filter result; should return []Finding{}")
+			}
+		})
+	}
+}
+
+func TestFilterCriticalFindings_PreservesOrder(t *testing.T) {
+	input := []Finding{
+		{Severity: SeverityCritical, Rule: "rule_A"},
+		{Severity: SeverityWarning, Rule: "rule_W"},
+		{Severity: SeverityCritical, Rule: "rule_B"},
+		{Severity: SeverityInfo, Rule: "rule_I"},
+		{Severity: SeverityCritical, Rule: "rule_C"},
+	}
+
+	got := FilterCriticalFindings(input)
+
+	if len(got) != 3 {
+		t.Fatalf("len(got)=%d, want 3", len(got))
+	}
+
+	rules := []string{"rule_A", "rule_B", "rule_C"}
+	for i, f := range got {
+		if f.Rule != rules[i] {
+			t.Errorf("got[%d].Rule=%q, want %q (order not preserved)", i, f.Rule, rules[i])
+		}
+	}
+}
+
+func TestFilterCriticalFindings_MemoryEfficiency(t *testing.T) {
+	input := make([]Finding, 1000)
+	for i := range input {
+		if i%100 == 0 {
+			input[i].Severity = SeverityCritical
+		} else {
+			input[i].Severity = SeverityWarning
+		}
+	}
+
+	got := FilterCriticalFindings(input)
+
+	if len(got) != 10 {
+		t.Errorf("len(got)=%d, want 10", len(got))
+	}
+	if cap(got) > 100 {
+		t.Logf("warning: capacity=%d for 10 items (may indicate over-allocation)", cap(got))
+	}
+}
+
+func TestReportHasCriticalAfterFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		findings []Finding
+		want     bool
+	}{
+		{
+			name: "critical exists after filter",
+			findings: []Finding{
+				{Severity: SeverityCritical},
+				{Severity: SeverityWarning},
+			},
+			want: true,
+		},
+		{
+			name: "no critical after filter",
+			findings: []Finding{
+				{Severity: SeverityWarning},
+				{Severity: SeverityInfo},
+			},
+			want: false,
+		},
+		{
+			name:     "empty after filter",
+			findings: []Finding{},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := FilterCriticalFindings(tt.findings)
+			report := &Report{Findings: filtered}
+
+			if got := report.HasCritical(); got != tt.want {
+				t.Errorf("HasCritical()=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReportCountBySeverityAfterFilter(t *testing.T) {
+	original := []Finding{
+		{Severity: SeverityCritical},
+		{Severity: SeverityCritical},
+		{Severity: SeverityWarning},
+		{Severity: SeverityWarning},
+		{Severity: SeverityInfo},
+	}
+
+	// After filter
+	filtered := FilterCriticalFindings(original)
+	report := &Report{Findings: filtered}
+
+	crit, warn, info := report.CountBySeverity()
+
+	if crit != 2 || warn != 0 || info != 0 {
+		t.Errorf("CountBySeverity()=(%d,%d,%d), want (2,0,0)", crit, warn, info)
+	}
+}
+
+func TestFilterCriticalFindings_Performance(t *testing.T) {
+	input := make([]Finding, 10000)
+	for i := range input {
+		if i%1000 == 0 {
+			input[i].Severity = SeverityCritical
+		} else {
+			input[i].Severity = SeverityWarning
+		}
+	}
+
+	got := FilterCriticalFindings(input)
+
+	if len(got) != 10 {
+		t.Errorf("len(got)=%d, want 10", len(got))
+	}
+}
+
+func TestFilterCriticalFindings_JSONMarshal(t *testing.T) {
+	input := []Finding{
+		{Severity: SeverityWarning, Title: "Warning"},
+		{Severity: SeverityInfo, Title: "Info"},
+	}
+
+	filtered := FilterCriticalFindings(input)
+	report := &Report{Findings: filtered}
+	data, err := json.Marshal(report.Findings)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	if string(data) == "null" {
+		t.Error("JSON marshaled to null; should be []")
+	}
+	if string(data) != "[]" {
+		t.Errorf("JSON=%s, want []", string(data))
+	}
+}

--- a/internal/doctor/finding_test.go
+++ b/internal/doctor/finding_test.go
@@ -1,5 +1,5 @@
 // Copyright 2026 Optiqor contributors
-// SDPX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 
 package doctor
 


### PR DESCRIPTION
<!--
Thanks for contributing to Kerno! A few notes:

- PR title must follow Conventional Commits: `feat(scope): subject` (linted in CI).
- Every commit must be DCO-signed (`git commit -s`).
- Squash merges are the default — your PR title becomes the merge commit.
- CI runs build + race tests + lint + (when configured) the kernel matrix.
-->

## What

add ' --only-critical' flag to 'kerno doctor' command that filters finding to only show critical severity items before rendering.

## Why

in CI/CD pipelines and scripts, users only care about critical findings and want to filter out warning and info level results. currently there's no way to filter the output.

Fixes #3 

## How

Added `FilterCriticalFindings()` function in `internal/doctor/engine.go` that returns only critical severity findings. Applied a filter in `runDiagnosticCycle()` after rule evaluation but before rendering so that both pretty and JSON respects the filter automatically. Exits 0 if no critical findings remain after filtering. Pre-allocates memory efficiently and handles nil/empty slices safely. 

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Tested locally with:  `sudo ./bin/kerno doctor --only-critical` to verify it only prints critical item. ` sudo ./bin/kerno doctor --only-critical --output json` prints JSON output nicely.

<!-- Required for changes touching internal/bpf/, internal/collector/, internal/doctor/. -->

- [x] N/A —  (only added a function in `engine.go`) 
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [x] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed
- [x] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`
