### PR TITLE
fix(config): validate ai max_tokens, rate_limit_per_minute, and temperature ranges

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,6 +213,15 @@ func (c *Config) Validate() error {
 		default:
 			return fmt.Errorf("invalid ai.privacy_mode %q: must be full, redacted, or summary", c.AI.PrivacyMode)
 		}
+		if c.AI.MaxTokens <= 0 {
+			return fmt.Errorf("ai.max_tokens must be > 0, got %d", c.AI.MaxTokens)
+		}
+		if c.AI.RateLimitPerMinute < 0 {
+			return fmt.Errorf("ai.rate_limit_per_minute must be >= 0, got %d", c.AI.RateLimitPerMinute)
+		}
+		if c.AI.Temperature < 0.0 || c.AI.Temperature > 1.0 {
+			return fmt.Errorf("ai.temperature must be in [0.0, 1.0], got %g", c.AI.Temperature)
+		}
 	}
 
 	if c.Prometheus.Enabled && c.Prometheus.Addr == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -83,6 +83,78 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "ai max_tokens must be positive",
+			modify: func(c *Config) {
+				c.AI.Enabled = true
+				c.AI.Provider = "ollama"
+				c.AI.MaxTokens = 0
+			},
+			wantErr: true,
+		},
+		{
+			name: "ai max_tokens negative",
+			modify: func(c *Config) {
+				c.AI.Enabled = true
+				c.AI.Provider = "ollama"
+				c.AI.MaxTokens = -1
+			},
+			wantErr: true,
+		},
+		{
+			name: "ai rate_limit_per_minute may not be negative",
+			modify: func(c *Config) {
+				c.AI.Enabled = true
+				c.AI.Provider = "ollama"
+				c.AI.RateLimitPerMinute = -1
+			},
+			wantErr: true,
+		},
+		{
+			name: "ai rate_limit_per_minute zero means unlimited",
+			modify: func(c *Config) {
+				c.AI.Enabled = true
+				c.AI.Provider = "ollama"
+				c.AI.RateLimitPerMinute = 0
+			},
+			wantErr: false,
+		},
+		{
+			name: "ai temperature below zero",
+			modify: func(c *Config) {
+				c.AI.Enabled = true
+				c.AI.Provider = "ollama"
+				c.AI.Temperature = -0.1
+			},
+			wantErr: true,
+		},
+		{
+			name: "ai temperature above one",
+			modify: func(c *Config) {
+				c.AI.Enabled = true
+				c.AI.Provider = "ollama"
+				c.AI.Temperature = 1.1
+			},
+			wantErr: true,
+		},
+		{
+			name: "ai temperature at zero lower bound",
+			modify: func(c *Config) {
+				c.AI.Enabled = true
+				c.AI.Provider = "ollama"
+				c.AI.Temperature = 0.0
+			},
+			wantErr: false,
+		},
+		{
+			name: "ai temperature at one upper bound",
+			modify: func(c *Config) {
+				c.AI.Enabled = true
+				c.AI.Provider = "ollama"
+				c.AI.Temperature = 1.0
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Add three range checks to `Config.Validate` for the AI block so out-of-range values are rejected at config-load time instead of silently propagating to the LLM client.

## Why

Fixes #129.

`Validate` accepted a negative `MaxTokens` or a `Temperature` outside 0.0–1.0, even though the `Temperature` field doc states the 0.0–1.0 range. The validation gap meant a typo in `kerno.yaml` could ship straight to the provider with no early failure.

## How

Inside the existing `if c.AI.Enabled` block (so disabled-AI configs still pass), after the existing privacy-mode switch:

- `MaxTokens > 0` — a zero or negative cap is meaningless for the LLM call.
- `RateLimitPerMinute >= 0` — zero is allowed and read as unlimited, mirroring how a missing rate limit behaves elsewhere; negative is rejected.
- `0.0 <= Temperature <= 1.0` — inclusive on both ends, matching the `Temperature` field doc.

No changes to defaults, no new fields, no public-API change.

## Testing

- [x] `go build ./internal/config/...` passes
- [x] `go test ./internal/config/...` passes (16/16 including 8 new boundary cases)
- [x] `go vet ./internal/config/...` passes
- [x] `golangci-lint run ./internal/config/...` (v2.1.6) passes — 0 issues
- [x] N/A — pure refactor; no eBPF / collector / doctor surface touched

The new table-test cases cover: `MaxTokens` zero and negative; `RateLimitPerMinute` negative (reject) and zero (accept, unlimited); `Temperature` below 0, above 1, and at both inclusive bounds (0.0 and 1.0).

## Checklist

- [x] PR title follows Conventional Commits
- [x] All commits are DCO-signed
- [x] No unrelated changes pulled in
- [x] Documentation N/A — field docs were already correct; this PR aligns runtime behavior with them
- [x] Added boundary tests for new code paths
- [x] N/A — not a new doctor rule