### PR TITLE
fix(ai): default analyzer logger when omitted

### DIFF
--- a/internal/ai/analyzer.go
+++ b/internal/ai/analyzer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 
 	"github.com/optiqor/kerno/internal/doctor"
@@ -35,11 +36,15 @@ func NewAnalyzer(cfg AnalyzerConfig) *DefaultAnalyzer {
 	if privacy == "" {
 		privacy = PrivacySummary
 	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
 	return &DefaultAnalyzer{
 		provider: cfg.Provider,
 		cache:    cfg.Cache,
 		privacy:  privacy,
-		logger:   cfg.Logger,
+		logger:   logger,
 	}
 }
 

--- a/internal/ai/analyzer_test.go
+++ b/internal/ai/analyzer_test.go
@@ -76,6 +76,22 @@ func TestAnalyzerHappyPath(t *testing.T) {
 	}
 }
 
+func TestAnalyzerUsesDiscardLoggerWhenNil(t *testing.T) {
+	prov := &scriptedProvider{text: `{"summary":"ok"}`}
+
+	a := NewAnalyzer(AnalyzerConfig{Provider: prov})
+	if a.logger == nil {
+		t.Fatal("logger should default when omitted")
+	}
+	resp, err := a.Analyze(context.Background(), doctor.AnalysisRequest{Signals: emptySignals()})
+	if err != nil {
+		t.Fatalf("Analyze error: %v", err)
+	}
+	if resp.Summary != "ok" {
+		t.Errorf("Summary = %q, want ok", resp.Summary)
+	}
+}
+
 func TestAnalyzerMarkdownFencedJSON(t *testing.T) {
 	prov := &scriptedProvider{text: "Here you go:\n```json\n{\"summary\":\"ok\"}\n```\n"}
 


### PR DESCRIPTION
Fixes #126

## Changes
- Default `AnalyzerConfig.Logger` to a discard slog logger when omitted
- Add coverage proving `NewAnalyzer` can run `Analyze` without a caller-provided logger

## Verification
- `go test ./internal/ai -count=1`
- `go test ./... -count=1`