### PR TITLE
fix(config): honor all KERNO_* env vars by registering defaults (#112)

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -108,7 +107,8 @@ and copy-paste fix steps.`,
 
 // initConfig reads the config file and environment variables.
 func initConfig(cmd *cobra.Command) error {
-	v := viper.New()
+	// config.NewViper wires up KERNO_* env var resolution for every key.
+	v := config.NewViper()
 
 	// Config file discovery.
 	// Precedence: --config flag > KERNO_CONFIG env > auto-discover.
@@ -125,11 +125,6 @@ func initConfig(cmd *cobra.Command) error {
 		v.AddConfigPath("$HOME/.kerno")
 		v.AddConfigPath(".")
 	}
-
-	// Environment variables: KERNO_LOG_LEVEL, KERNO_PROMETHEUS_ADDR, etc.
-	v.SetEnvPrefix("KERNO")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
-	v.AutomaticEnv()
 
 	// Bind CLI flags to viper.
 	if err := v.BindPFlag("log_level", cmd.Root().PersistentFlags().Lookup("log-level")); err != nil {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// NewViper returns a viper instance wired to resolve KERNO_* environment
+// variables for every configuration key.
+//
+// Viper's AutomaticEnv only resolves a key at Get time for keys it already
+// knows about, and Unmarshal walks the known-key set (AllKeys). Without any
+// defaults, file, or bindings registered, that set is empty, so KERNO_* env
+// vars silently resolve to nothing. To make the documented precedence
+// (flags > env > file > defaults) hold for the whole env tier, we register
+// every key from Default() as a viper default. Defaults are the lowest
+// precedence tier, so a changed flag, an env var, and a config file all still
+// override them. Because the keys are derived from the struct's mapstructure
+// tags, any future field is covered automatically.
+func NewViper() *viper.Viper {
+	v := viper.New()
+
+	// Environment variables: KERNO_LOG_LEVEL, KERNO_PROMETHEUS_ADDR, etc.
+	v.SetEnvPrefix("KERNO")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	v.AutomaticEnv()
+
+	// Register every key so AutomaticEnv and Unmarshal can see them.
+	defaults := make(map[string]any)
+	flattenDefaults("", reflect.ValueOf(*Default()), defaults)
+	for key, val := range defaults {
+		v.SetDefault(key, val)
+	}
+
+	return v
+}
+
+// flattenDefaults walks a config struct and records each leaf field under its
+// dotted mapstructure key (e.g. "ai.api_key",
+// "doctor.thresholds.tcp_retransmit_pct") in out. Nested structs are recursed
+// into; everything else (including time.Duration, whose Kind is Int64) is a
+// leaf.
+func flattenDefaults(prefix string, rv reflect.Value, out map[string]any) {
+	rt := rv.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+
+		name, _, _ := strings.Cut(field.Tag.Get("mapstructure"), ",")
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = strings.ToLower(field.Name)
+		}
+
+		key := name
+		if prefix != "" {
+			key = prefix + "." + name
+		}
+
+		fv := rv.Field(i)
+		if fv.Kind() == reflect.Struct {
+			flattenDefaults(key, fv, out)
+			continue
+		}
+		out[key] = fv.Interface()
+	}
+}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// TestNewViperEnvOverrides verifies that KERNO_* environment variables flow
+// through to the typed config. This guards against the regression in #112,
+// where AutomaticEnv had no registered keys and silently dropped every env var
+// except the three bound flags.
+func TestNewViperEnvOverrides(t *testing.T) {
+	// Covers a string flag key (per the issue), plus keys that were broken
+	// before the fix across every value type: string, bool, and duration.
+	t.Setenv("KERNO_LOG_LEVEL", "debug")
+	t.Setenv("KERNO_AI_API_KEY", "secret")
+	t.Setenv("KERNO_AI_ENABLED", "true")
+	t.Setenv("KERNO_PROMETHEUS_ADDR", ":1234")
+	t.Setenv("KERNO_DOCTOR_DURATION", "45s")
+
+	cfg := Default()
+	if err := NewViper().Unmarshal(cfg); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want %q (KERNO_LOG_LEVEL)", cfg.LogLevel, "debug")
+	}
+	if cfg.AI.APIKey != "secret" {
+		t.Errorf("AI.APIKey = %q, want %q (KERNO_AI_API_KEY)", cfg.AI.APIKey, "secret")
+	}
+	if !cfg.AI.Enabled {
+		t.Error("AI.Enabled = false, want true (KERNO_AI_ENABLED)")
+	}
+	if cfg.Prometheus.Addr != ":1234" {
+		t.Errorf("Prometheus.Addr = %q, want %q (KERNO_PROMETHEUS_ADDR)", cfg.Prometheus.Addr, ":1234")
+	}
+	if cfg.Doctor.Duration != 45*time.Second {
+		t.Errorf("Doctor.Duration = %s, want 45s (KERNO_DOCTOR_DURATION)", cfg.Doctor.Duration)
+	}
+}
+
+// TestNewViperDefaultsPreserved ensures that registering keys as viper defaults
+// does not clobber the values from Default() when no env var is set.
+func TestNewViperDefaultsPreserved(t *testing.T) {
+	cfg := Default()
+	if err := NewViper().Unmarshal(cfg); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	want := Default()
+	if cfg.LogLevel != want.LogLevel {
+		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, want.LogLevel)
+	}
+	if cfg.Prometheus.Addr != want.Prometheus.Addr {
+		t.Errorf("Prometheus.Addr = %q, want %q", cfg.Prometheus.Addr, want.Prometheus.Addr)
+	}
+	if cfg.Doctor.Duration != want.Doctor.Duration {
+		t.Errorf("Doctor.Duration = %s, want %s", cfg.Doctor.Duration, want.Doctor.Duration)
+	}
+	if cfg.Collectors.SyscallLatency != want.Collectors.SyscallLatency {
+		t.Errorf("Collectors.SyscallLatency = %v, want %v", cfg.Collectors.SyscallLatency, want.Collectors.SyscallLatency)
+	}
+	if cfg.Doctor.Thresholds.TCPRetransmitPct != want.Doctor.Thresholds.TCPRetransmitPct {
+		t.Errorf("Doctor.Thresholds.TCPRetransmitPct = %v, want %v",
+			cfg.Doctor.Thresholds.TCPRetransmitPct, want.Doctor.Thresholds.TCPRetransmitPct)
+	}
+}
+
+// TestFlattenDefaults checks that the reflection walker produces the expected
+// dotted keys, including deeply nested ones, so AutomaticEnv can resolve their
+// KERNO_* counterparts.
+func TestFlattenDefaults(t *testing.T) {
+	keys := make(map[string]any)
+	flattenDefaults("", reflect.ValueOf(*Default()), keys)
+
+	want := []string{
+		"log_level",
+		"ai.api_key",
+		"ai.enabled",
+		"prometheus.addr",
+		"doctor.duration",
+		"doctor.thresholds.tcp_retransmit_pct",
+		"collectors.syscall_latency",
+	}
+	for _, k := range want {
+		if _, ok := keys[k]; !ok {
+			t.Errorf("flattenDefaults() missing key %q", k)
+		}
+	}
+}


### PR DESCRIPTION
## What

makes every `KERNO_*` env var actually apply. before this only the three bound flags (`log_level`, `log_format`, `no_color`) worked; everything else, including `KERNO_AI_API_KEY`, `KERNO_PROMETHEUS_ADDR`, and `KERNO_AI_ENABLED`, silently resolved to nothing.

## Why

Fixes #112

`initConfig` enabled `AutomaticEnv` but never registered any keys, so viper's known-key set (`AllKeys()`) was empty and both env resolution and `Unmarshal` had nothing to populate. full root-cause writeup is in my comment on the issue.

## How

added `config.NewViper()` that walks `config.Default()` by its mapstructure tags and registers each key with `SetDefault`. defaults are the lowest tier, so `flag > env > file > default` is preserved, and because keys come from the struct, new config fields are covered automatically (won't silently regress). `root.go` builds its viper through the helper; file discovery, flag binding, and validation are unchanged.

## Testing

- [x] `go build ./...` passes (`GOOS=linux` cross-compile of the full tree)
- [x] `go test ./...` passes (config suite green; the eBPF packages are linux/root-only and run in CI)
- [x] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes (not run locally, leaving for CI)
- [x] Tested locally with: `go test ./internal/config/... -v`

- [x] N/A — no eBPF/collector/doctor code touched

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed (none needed, the env vars are already documented, this just makes them work)
- [x] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh` (n/a)