### PR TITLE
refactor(bpf): remove dead LoaderSet and simplify loader management

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,7 +293,7 @@ kerno/
 │   │   │   ├── disk_io.c
 │   │   │   ├── sched_delay.c
 │   │   │   └── fd_track.c
-│   │   ├── loader.go           # Loader interface + LoaderSet
+│   │   ├── loader.go           # Loader interface
 │   │   ├── events.go           # Go event structs (mirror C structs)
 │   │   ├── gen_stub.go         # Stub types for dev builds (no clang)
 │   │   ├── syscall_latency.go  # Typed loader for syscall program
@@ -340,7 +340,7 @@ kerno/
 
 - **`internal/`** - All packages are internal; the only public API is the CLI binary.
 - **Build tag strategy** - `gen_stub.go` (`//go:build !ebpf`) provides stub types so `make build` works without clang. `make generate` post-processes the BPF-generated types to require the `ebpf` build tag, making stubs and generated files mutually exclusive.
-- **Loader interface** - Each eBPF program has a typed Go loader implementing a common `Loader` interface, enabling uniform lifecycle management via `LoaderSet`.
+- **Loader interface** - Each eBPF program has a typed Go loader implementing a common `Loader` interface.
 - **Collector interface** - Collectors consume raw events from loaders, aggregate them into typed snapshots, and expose them via a `Registry` for the doctor engine.
 
 ---
@@ -384,7 +384,7 @@ kerno/
 # 1. Create C source in internal/bpf/c/
 # 2. Create Go loader in internal/bpf/
 # 3. Add stub types in gen_stub.go
-# 4. Register in LoaderSet
+# 4. Register in start.go and doctor.go
 # 5. Run: make build-ebpf && make test
 
 # Adding a new CLI command:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,6 @@
    - [5.2 How bpf2go Code Generation Works](#52-how-bpf2go-code-generation-works)
    - [5.3 The Stub System (Building Without Clang)](#53-the-stub-system-building-without-clang)
    - [5.4 Event Types in Go](#54-event-types-in-go)
-   - [5.5 LoaderSet: Managing Multiple Programs](#55-loaderset-managing-multiple-programs)
 6. [Layer 3 - Collector Framework (Aggregation)](#6-layer-3--collector-framework-aggregation)
    - [6.1 The Collector Interface](#61-the-collector-interface)
    - [6.2 The Registry](#62-the-registry)
@@ -153,7 +152,7 @@ kerno/
 │   │   │   ├── disk_io.c
 │   │   │   ├── sched_delay.c
 │   │   │   └── fd_track.c
-│   │   ├── loader.go              ← Loader interface + LoaderSet
+│   │   ├── loader.go              ← Loader interface
 │   │   ├── events.go              ← Go event structs (match C exactly)
 │   │   ├── gen_stub.go            ← Stub objects for non-eBPF builds
 │   │   ├── syscall_latency.go     ← Go loader for syscall_latency
@@ -562,24 +561,6 @@ Each event type has helper methods:
 - `Latency()` / `RunqDelay()` / `RTT()` - converts nanosecond fields to `time.Duration`
 - `SrcAddr()` / `DstAddr()` - converts uint32 to `net.IP`
 - `OpString()` - converts operation byte to "read"/"write"/"sync"
-
-### 5.5 LoaderSet: Managing Multiple Programs
-
-`LoaderSet` provides batch lifecycle management:
-
-```go
-set := bpf.NewLoaderSet(logger,
-    bpf.NewSyscallLatencyLoader(logger),
-    bpf.NewTCPMonitorLoader(logger),
-    bpf.NewDiskIOLoader(logger),
-    // ...
-)
-
-set.LoadAll()   // Load all into kernel (fails on first error)
-defer set.Close()  // Detach and unload all (reverse order)
-```
-
-The `start` command uses individual loading with graceful degradation instead - if one program fails, the others still run.
 
 ---
 

--- a/internal/bpf/loader.go
+++ b/internal/bpf/loader.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 )
 
 // Loader is the interface that all eBPF program loaders must implement.
@@ -77,56 +76,6 @@ func (t EventType) String() string {
 	default:
 		return fmt.Sprintf("unknown(%d)", t)
 	}
-}
-
-// LoaderSet manages the lifecycle of multiple eBPF program loaders.
-type LoaderSet struct {
-	loaders []Loader
-	closers []io.Closer
-	logger  *slog.Logger
-}
-
-// NewLoaderSet creates a new set of eBPF program loaders.
-func NewLoaderSet(logger *slog.Logger, loaders ...Loader) *LoaderSet {
-	return &LoaderSet{
-		loaders: loaders,
-		logger:  logger,
-	}
-}
-
-// LoadAll loads all eBPF programs into the kernel.
-// Returns an error if any program fails to load, after cleaning up
-// all previously loaded programs.
-func (s *LoaderSet) LoadAll() error {
-	for _, l := range s.loaders {
-		s.logger.Info("loading eBPF program", "name", l.Name())
-
-		closer, err := l.Load()
-		if err != nil {
-			// Clean up everything loaded so far.
-			s.Close()
-			return fmt.Errorf("loading %s: %w", l.Name(), err)
-		}
-		s.closers = append(s.closers, closer)
-
-		s.logger.Info("loaded eBPF program", "name", l.Name())
-	}
-	return nil
-}
-
-// Close detaches and unloads all eBPF programs.
-func (s *LoaderSet) Close() {
-	for i := len(s.closers) - 1; i >= 0; i-- {
-		if err := s.closers[i].Close(); err != nil {
-			s.logger.Warn("error closing eBPF program", "error", err)
-		}
-	}
-	s.closers = nil
-}
-
-// Loaders returns the underlying loaders for event consumption.
-func (s *LoaderSet) Loaders() []Loader {
-	return s.loaders
 }
 
 // closerFunc adapts a plain function to the io.Closer interface.

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -94,7 +94,7 @@ func runStart(ctx context.Context, opts startOpts) error {
 	}
 
 	// Phase 1: Load eBPF programs with graceful degradation.
-	loaders, loaderSet := buildLoaders(logger)
+	loaders := buildLoaders(logger)
 	loadedCount := 0
 	closers := make([]func(), 0, len(loaders))
 
@@ -136,7 +136,7 @@ func runStart(ctx context.Context, opts startOpts) error {
 
 	// Phase 2: Start the metrics bridge — reads BPF events and feeds Prometheus.
 	bridge := metrics.NewBridge(logger)
-	bridge.Start(ctx, loaderSet.Loaders())
+	bridge.Start(ctx, loaders)
 	defer bridge.Stop()
 
 	// Phase 2b: Start environment adapter for event enrichment.
@@ -203,7 +203,7 @@ func runStart(ctx context.Context, opts startOpts) error {
 }
 
 // buildLoaders creates the set of BPF loaders based on config.
-func buildLoaders(logger *slog.Logger) ([]bpf.Loader, *bpf.LoaderSet) {
+func buildLoaders(logger *slog.Logger) []bpf.Loader {
 	var loaders []bpf.Loader
 
 	if cfg.Collectors.SyscallLatency {
@@ -225,8 +225,7 @@ func buildLoaders(logger *slog.Logger) ([]bpf.Loader, *bpf.LoaderSet) {
 		loaders = append(loaders, bpf.NewFDTrackLoader(logger))
 	}
 
-	set := bpf.NewLoaderSet(logger, loaders...)
-	return loaders, set
+	return loaders
 }
 
 // healthzHandler returns the health check handler.


### PR DESCRIPTION
Closes #128 


<!--
Thanks for contributing to Kerno! A few notes:

- PR title must follow Conventional Commits: `feat(scope): subject` (linted in CI).
- Every commit must be DCO-signed (`git commit -s`).
- Squash merges are the default — your PR title becomes the merge commit.
- CI runs build + race tests + lint + (when configured) the kernel matrix.
-->

## What

This PR removes the unused, dead-code `LoaderSet` struct and its associated constructor (`NewLoaderSet`) and methods (`LoadAll`, `Close`, `Loaders`) from [loader.go](file:///d:/GSSoC/Kerno/%23128/kerno/internal/bpf/loader.go).

## Why

`LoaderSet.LoadAll` and `LoaderSet.Close` had no callers in production or tests. In addition, the `LoadAll` method would tear down all successfully loaded eBPF programs as soon as a single one failed to load, which directly contradicted Kerno's graceful-degradation invariant.

Fixes #3
Relates to #128 

## How

- Removed the `LoaderSet` definition, constructor, and methods from [loader.go](file:///d:/GSSoC/Kerno/%23128/kerno/internal/bpf/loader.go), and cleaned up the now-unused `"log/slog"` import.
- Preserved the `closerFunc` helper in [loader.go](file:///d:/GSSoC/Kerno/%23128/kerno/internal/bpf/loader.go) since it is actively used by individual program loaders.
- Updated `buildLoaders` and `runStart` in [start.go](file:///d:/GSSoC/Kerno/%23128/kerno/internal/cli/start.go) to pass and consume a raw `[]bpf.Loader` slice instead of the wrapped `*bpf.LoaderSet`.
- Updated documentation and internal task guides in [architecture.md](file:///d:/GSSoC/Kerno/%23128/kerno/docs/architecture.md) and [CONTRIBUTING.md](file:///d:/GSSoC/Kerno/%23128/kerno/CONTRIBUTING.md) to reflect the removal of `LoaderSet`.

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes

- [x] N/A — pure docs/refactor

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed
- [x] Added/updated tests for new code paths
