### PR TITLE
test(doctor): table-drive render_test.go

### DIFF
--- a/internal/doctor/render_test.go
+++ b/internal/doctor/render_test.go
@@ -51,265 +51,349 @@ func sampleReport() *Report {
 	}
 }
 
-func TestPrettyRenderer_ContainsHeader(t *testing.T) {
-	var buf bytes.Buffer
-	r := &PrettyRenderer{NoColor: true}
-	report := sampleReport()
+// ─── PrettyRenderer ────────────────────────────────────────────────────────
 
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	output := buf.String()
-
-	checks := []string{
-		"KERNO DOCTOR",
-		"Kernel Diagnostic Report",
-		"prod-db-01",
-		"6.8.0-generic",
-		"FINDINGS",
-		"1 critical",
-		"Disk I/O Bottleneck Detected",
-		"File Descriptor Leak Suspected",
-		"sync P99=300ms",
-		"iostat -x 1 5",
-		"SYSTEM SUMMARY",
-		"15000",
-	}
-
-	for _, check := range checks {
-		if !strings.Contains(output, check) {
-			t.Errorf("pretty output missing %q", check)
-		}
-	}
-}
-
-func TestPrettyRenderer_NoBanner(t *testing.T) {
-	var buf bytes.Buffer
-	// Set NoBanner to true
-	r := &PrettyRenderer{NoColor: true, NoBanner: true}
-	report := sampleReport()
-
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	output := buf.String()
-
-	if strings.Contains(output, "KERNO DOCTOR") {
-		t.Error("pretty output should NOT contain KERNO DOCTOR banner when NoBanner is true")
-	}
-
-	if !strings.Contains(output, "FINDINGS") {
-		t.Error("pretty output should still contain FINDINGS")
-	}
-}
-
-func TestPrettyRenderer_HealthySystem(t *testing.T) {
-	var buf bytes.Buffer
-	r := &PrettyRenderer{NoColor: true}
-	report := &Report{
-		Duration: 30 * time.Second,
-		Findings: []Finding{
-			{
-				Severity: SeverityInfo,
-				Rule:     "healthy_system",
-				Title:    "System Healthy",
-				Signal:   "all",
-				Evidence: "All kernel signals within normal thresholds",
+func TestPrettyRenderer(t *testing.T) {
+	tests := []struct {
+		name            string
+		report          *Report
+		noBanner        bool
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:     "header with findings",
+			report:   sampleReport(),
+			noBanner: false,
+			wantContains: []string{
+				"KERNO DOCTOR",
+				"Kernel Diagnostic Report",
+				"prod-db-01",
+				"6.8.0-generic",
+				"FINDINGS",
+				"1 critical",
+				"Disk I/O Bottleneck Detected",
+				"File Descriptor Leak Suspected",
+				"sync P99=300ms",
+				"iostat -x 1 5",
+				"SYSTEM SUMMARY",
+				"15000",
+			},
+		},
+		{
+			name:     "no banner",
+			report:   sampleReport(),
+			noBanner: true,
+			wantContains: []string{
+				"FINDINGS",
+			},
+			wantNotContains: []string{
+				"KERNO DOCTOR",
+			},
+		},
+		{
+			name: "healthy system",
+			report: &Report{
+				Duration: 30 * time.Second,
+				Findings: []Finding{
+					{
+						Severity: SeverityInfo,
+						Rule:     "healthy_system",
+						Title:    "System Healthy",
+						Signal:   "all",
+						Evidence: "All kernel signals within normal thresholds",
+					},
+				},
+			},
+			noBanner: false,
+			wantContains: []string{
+				"System Healthy",
+				"0 critical",
+			},
+		},
+		{
+			name: "AI analysis",
+			report: func() *Report {
+				r := sampleReport()
+				r.Analysis = &AnalysisResponse{
+					Summary: "Disk saturation is causing cascading latency.",
+					Correlations: []Correlation{
+						{Signals: []string{"diskio", "syscall"}, Description: "Disk bottleneck causing slow fsync", Confidence: 0.9},
+					},
+					RootCauses: []RootCause{
+						{Description: "NVMe SSD nearing end of life", Fix: "Replace drive"},
+					},
+				}
+				return r
+			}(),
+			noBanner: false,
+			wantContains: []string{
+				"AI ANALYSIS",
+				"Disk saturation is causing cascading latency",
+				"diskio + syscall",
+				"NVMe SSD nearing end of life",
+			},
+		},
+		{
+			name:     "recommended action order",
+			report:   sampleReport(),
+			noBanner: false,
+			wantContains: []string{
+				"RECOMMENDED ACTION ORDER",
+				"[NOW]",
+			},
+		},
+		{
+			name:     "empty findings",
+			report:   &Report{Duration: 10 * time.Second, Findings: nil},
+			noBanner: false,
+			wantContains: []string{
+				"0 critical · 0 warning · 0 info",
+			},
+			wantNotContains: []string{
+				"RECOMMENDED ACTION ORDER",
+			},
+		},
+		{
+			name: "single info finding",
+			report: &Report{
+				Duration: 10 * time.Second,
+				Findings: []Finding{
+					{
+						Severity: SeverityInfo,
+						Rule:     "info_finding",
+						Title:    "Info Finding Title",
+						Signal:   "all",
+						Evidence: "All normal",
+					},
+				},
+			},
+			noBanner: false,
+			wantContains: []string{
+				"0 critical · 0 warning · 1 info",
+				"Info Finding Title",
+			},
+		},
+		{
+			name: "bar ratio below zero clamped",
+			report: &Report{
+				Duration: 10 * time.Second,
+				Findings: []Finding{
+					{
+						Severity:  SeverityCritical,
+						Rule:      "neg_bar",
+						Title:     "Negative Bar Finding",
+						Signal:    "sig",
+						Evidence:  "ev",
+						Value:     -10,
+						Threshold: 100,
+					},
+				},
+			},
+			noBanner: false,
+			wantContains: []string{
+				"Negative Bar Finding",
+			},
+			wantNotContains: []string{
+				"Limit",
+			},
+		},
+		{
+			name: "bar width capped at prBarWidth",
+			report: &Report{
+				Duration: 10 * time.Second,
+				Findings: []Finding{
+					{
+						Severity:  SeverityCritical,
+						Rule:      "cap_bar",
+						Title:     "Capped Bar Finding",
+						Signal:    "sig",
+						Evidence:  "ev",
+						Value:     1e9,
+						Threshold: 1,
+					},
+				},
+			},
+			noBanner: false,
+			wantContains: []string{
+				"Capped Bar Finding",
+				"▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇",
 			},
 		},
 	}
 
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			r := &PrettyRenderer{NoColor: true, NoBanner: tt.noBanner}
+			if err := r.Render(&buf, tt.report); err != nil {
+				t.Fatalf("Render failed: %v", err)
+			}
+			output := buf.String()
 
-	output := buf.String()
-	if !strings.Contains(output, "System Healthy") {
-		t.Error("pretty output missing 'System Healthy'")
-	}
-	if !strings.Contains(output, "0 critical") {
-		t.Error("pretty output should show 0 critical findings")
+			for _, check := range tt.wantContains {
+				if !strings.Contains(output, check) {
+					t.Errorf("pretty output missing %q", check)
+				}
+			}
+			for _, check := range tt.wantNotContains {
+				if strings.Contains(output, check) {
+					t.Errorf("pretty output should NOT contain %q", check)
+				}
+			}
+		})
 	}
 }
 
-func TestPrettyRenderer_AIAnalysis(t *testing.T) {
-	var buf bytes.Buffer
-	r := &PrettyRenderer{NoColor: true}
-	report := sampleReport()
-	report.Analysis = &AnalysisResponse{
-		Summary: "Disk saturation is causing cascading latency.",
-		Correlations: []Correlation{
-			{Signals: []string{"diskio", "syscall"}, Description: "Disk bottleneck causing slow fsync", Confidence: 0.9},
+// ─── JSONRenderer ──────────────────────────────────────────────────────────
+
+func TestJSONRenderer(t *testing.T) {
+	tests := []struct {
+		name   string
+		report *Report
+		pretty bool
+		check  func(t *testing.T, raw string, jr jsonReport)
+	}{
+		{
+			name:   "pretty valid JSON with summary",
+			report: sampleReport(),
+			pretty: true,
+			check: func(t *testing.T, raw string, jr jsonReport) {
+				if jr.Hostname != "prod-db-01" {
+					t.Errorf("hostname=%q, want prod-db-01", jr.Hostname)
+				}
+				if jr.KernelVer != "6.8.0-generic" {
+					t.Errorf("kernelVer=%q, want 6.8.0-generic", jr.KernelVer)
+				}
+				if len(jr.Findings) != 2 {
+					t.Errorf("findings=%d, want 2", len(jr.Findings))
+				}
+				if jr.Summary.Critical != 1 {
+					t.Errorf("critical=%d, want 1", jr.Summary.Critical)
+				}
+				if jr.Summary.Warning != 1 {
+					t.Errorf("warning=%d, want 1", jr.Summary.Warning)
+				}
+				if jr.Summary.EventsCollected != 15000 {
+					t.Errorf("eventsCollected=%d, want 15000", jr.Summary.EventsCollected)
+				}
+			},
 		},
-		RootCauses: []RootCause{
-			{Description: "NVMe SSD nearing end of life", Fix: "Replace drive"},
+		{
+			name:   "finding fields and ETA",
+			report: sampleReport(),
+			pretty: false,
+			check: func(t *testing.T, raw string, jr jsonReport) {
+				// Check the critical finding.
+				f := jr.Findings[0]
+				if f.Severity != "CRITICAL" {
+					t.Errorf("severity=%q, want CRITICAL", f.Severity)
+				}
+				if f.Rule != "disk_io_bottleneck" {
+					t.Errorf("rule=%q, want disk_io_bottleneck", f.Rule)
+				}
+				if len(f.Fix) != 2 {
+					t.Errorf("fix count=%d, want 2", len(f.Fix))
+				}
+
+				// Check the warning finding has ETA.
+				w := jr.Findings[1]
+				if w.ETA == "" {
+					t.Error("warning finding should have ETA")
+				}
+			},
+		},
+		{
+			name:   "compact is single line",
+			report: sampleReport(),
+			pretty: false,
+			check: func(t *testing.T, raw string, jr jsonReport) {
+				// Compact JSON should be a single line (plus trailing newline from Encoder).
+				lines := strings.Split(strings.TrimSpace(raw), "\n")
+				if len(lines) != 1 {
+					t.Errorf("compact JSON should be 1 line, got %d", len(lines))
+				}
+			},
+		},
+		{
+			name: "AI analysis block",
+			report: func() *Report {
+				r := sampleReport()
+				r.Analysis = &AnalysisResponse{
+					Summary: "Test summary",
+				}
+				return r
+			}(),
+			pretty: true,
+			check: func(t *testing.T, raw string, jr jsonReport) {
+				if jr.Analysis == nil {
+					t.Error("expected analysis in JSON output")
+				}
+				if jr.Analysis.Summary != "Test summary" {
+					t.Errorf("analysis summary=%q, want 'Test summary'", jr.Analysis.Summary)
+				}
+			},
+		},
+		{
+			name:   "empty findings",
+			report: &Report{Hostname: "test", Duration: 10 * time.Second},
+			pretty: true,
+			check: func(t *testing.T, raw string, jr jsonReport) {
+				if jr.Findings != nil && len(jr.Findings) != 0 {
+					t.Errorf("expected nil or empty findings, got %d", len(jr.Findings))
+				}
+			},
+		},
+		{
+			name: "single finding round-trip",
+			report: &Report{
+				Hostname: "test",
+				Duration: 10 * time.Second,
+				Findings: []Finding{
+					{
+						Severity: SeverityWarning,
+						Rule:     "some_warning",
+						Title:    "Warning Title",
+						Signal:   "sig",
+						Evidence: "ev",
+					},
+				},
+			},
+			pretty: true,
+			check: func(t *testing.T, raw string, jr jsonReport) {
+				if len(jr.Findings) != 1 {
+					t.Fatalf("expected 1 finding, got %d", len(jr.Findings))
+				}
+				f := jr.Findings[0]
+				if f.Severity != "WARNING" {
+					t.Errorf("severity=%q, want WARNING", f.Severity)
+				}
+				if f.Rule != "some_warning" {
+					t.Errorf("rule=%q, want some_warning", f.Rule)
+				}
+				if jr.Summary.Warning != 1 {
+					t.Errorf("summary warning=%d, want 1", jr.Summary.Warning)
+				}
+			},
 		},
 	}
 
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			r := &JSONRenderer{Pretty: tt.pretty}
+			if err := r.Render(&buf, tt.report); err != nil {
+				t.Fatalf("Render failed: %v", err)
+			}
 
-	output := buf.String()
-	checks := []string{
-		"AI ANALYSIS",
-		"Disk saturation is causing cascading latency",
-		"diskio + syscall",
-		"NVMe SSD nearing end of life",
-	}
-	for _, check := range checks {
-		if !strings.Contains(output, check) {
-			t.Errorf("AI analysis output missing %q", check)
-		}
-	}
-}
+			var jr jsonReport
+			if err := json.Unmarshal(buf.Bytes(), &jr); err != nil {
+				t.Fatalf("invalid JSON output: %v", err)
+			}
 
-func TestPrettyRenderer_RecommendedActionOrder(t *testing.T) {
-	var buf bytes.Buffer
-	r := &PrettyRenderer{NoColor: true}
-	report := sampleReport()
-
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	output := buf.String()
-	if !strings.Contains(output, "RECOMMENDED ACTION ORDER") {
-		t.Error("pretty output missing RECOMMENDED ACTION ORDER section")
-	}
-	if !strings.Contains(output, "[NOW]") {
-		t.Error("pretty output missing [NOW] urgency for critical finding")
-	}
-}
-
-func TestJSONRenderer_ValidJSON(t *testing.T) {
-	var buf bytes.Buffer
-	r := &JSONRenderer{Pretty: true}
-	report := sampleReport()
-
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	var jr jsonReport
-	if err := json.Unmarshal(buf.Bytes(), &jr); err != nil {
-		t.Fatalf("invalid JSON output: %v", err)
-	}
-
-	if jr.Hostname != "prod-db-01" {
-		t.Errorf("hostname=%q, want prod-db-01", jr.Hostname)
-	}
-	if jr.KernelVer != "6.8.0-generic" {
-		t.Errorf("kernelVer=%q, want 6.8.0-generic", jr.KernelVer)
-	}
-	if len(jr.Findings) != 2 {
-		t.Errorf("findings=%d, want 2", len(jr.Findings))
-	}
-	if jr.Summary.Critical != 1 {
-		t.Errorf("critical=%d, want 1", jr.Summary.Critical)
-	}
-	if jr.Summary.Warning != 1 {
-		t.Errorf("warning=%d, want 1", jr.Summary.Warning)
-	}
-	if jr.Summary.EventsCollected != 15000 {
-		t.Errorf("eventsCollected=%d, want 15000", jr.Summary.EventsCollected)
-	}
-}
-
-func TestJSONRenderer_FindingFields(t *testing.T) {
-	var buf bytes.Buffer
-	r := &JSONRenderer{Pretty: false}
-	report := sampleReport()
-
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	var jr jsonReport
-	if err := json.Unmarshal(buf.Bytes(), &jr); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
-
-	// Check the critical finding.
-	f := jr.Findings[0]
-	if f.Severity != "CRITICAL" {
-		t.Errorf("severity=%q, want CRITICAL", f.Severity)
-	}
-	if f.Rule != "disk_io_bottleneck" {
-		t.Errorf("rule=%q, want disk_io_bottleneck", f.Rule)
-	}
-	if len(f.Fix) != 2 {
-		t.Errorf("fix count=%d, want 2", len(f.Fix))
-	}
-
-	// Check the warning finding has ETA.
-	w := jr.Findings[1]
-	if w.ETA == "" {
-		t.Error("warning finding should have ETA")
-	}
-}
-
-func TestJSONRenderer_Compact(t *testing.T) {
-	var buf bytes.Buffer
-	r := &JSONRenderer{Pretty: false}
-	report := sampleReport()
-
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	// Compact JSON should be a single line (plus trailing newline from Encoder).
-	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-	if len(lines) != 1 {
-		t.Errorf("compact JSON should be 1 line, got %d", len(lines))
-	}
-}
-
-func TestJSONRenderer_WithAIAnalysis(t *testing.T) {
-	var buf bytes.Buffer
-	r := &JSONRenderer{Pretty: true}
-	report := sampleReport()
-	report.Analysis = &AnalysisResponse{
-		Summary: "Test summary",
-	}
-
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	var jr jsonReport
-	if err := json.Unmarshal(buf.Bytes(), &jr); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
-
-	if jr.Analysis == nil {
-		t.Error("expected analysis in JSON output")
-	}
-	if jr.Analysis.Summary != "Test summary" {
-		t.Errorf("analysis summary=%q, want 'Test summary'", jr.Analysis.Summary)
-	}
-}
-
-func TestJSONRenderer_EmptyFindings(t *testing.T) {
-	var buf bytes.Buffer
-	r := &JSONRenderer{Pretty: true}
-	report := &Report{
-		Hostname: "test",
-		Duration: 10 * time.Second,
-	}
-
-	if err := r.Render(&buf, report); err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	var jr jsonReport
-	if err := json.Unmarshal(buf.Bytes(), &jr); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
-
-	if jr.Findings != nil && len(jr.Findings) != 0 {
-		t.Errorf("expected nil or empty findings, got %d", len(jr.Findings))
+			tt.check(t, buf.String(), jr)
+		})
 	}
 }


### PR DESCRIPTION
Closes #131 


## What

Refactors `internal/doctor/render_test.go` from 10 flat, sequential test functions into two clean, table-driven test suites (`TestPrettyRenderer` and `TestJSONRenderer`) utilising `t.Run` and `t.Parallel()`.

## Why

Fixes #131

Organizing the test suite into structured tables improves maintainability and makes adding edge case coverage straightforward. Mirroring `internal/cli/trace_test.go` establishes a consistent testing pattern across packages.

## How

- Consolidated 5 `PrettyRenderer` tests under `TestPrettyRenderer`, preserving all original assertions.
- Added new subtests to cover specific edge cases:
  - `"empty findings"`: Ensures nil findings don't trigger panics, verify triage counts, and verify omission of recommended actions.
  - `"single info finding"`: Verifies correct formatting of informational severity findings. Note that info-level findings are excluded from recommended action order by `filterActionable` design.
  - `"bar ratio below zero clamped"`: Confirms that negative value findings are handled safely without panic (ignoring bar rendering due to value-check guard).
  - `"bar width capped at prBarWidth"`: Confirms that extreme value ratios cap visually to exactly 32 block characters.
- Consolidated 5 `JSONRenderer` tests under `TestJSONRenderer` with a generalised validation signature (`check` func).
- Added a new subtest `"single finding round-trip"` to verify JSON field mapping.
- Ensured concurrency safety under `t.Parallel()` using Go 1.22+ loop variable per-iteration scoping, and independent buffer writers and fresh report fixtures per subtest.

## Testing

- [x] `go build ./...` passes (validated against `render.go` signature constraints)
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Tested locally with: `go test -v -race ./internal/doctor/` (manually verified parallel execution and race-detector safety)

- [x] N/A — pure docs/refactor
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behaviour changed
- [x] Added/updated tests for new code paths
- [x] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`