### PR TITLE
fix(doctor): clamp eta duration conversion

### DIFF
--- a/internal/doctor/eta.go
+++ b/internal/doctor/eta.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package doctor
+
+import (
+	"math"
+	"time"
+)
+
+const maxMeaningfulETA = 7 * 24 * time.Hour
+
+func etaFromSeconds(seconds float64) (time.Duration, bool) {
+	if seconds <= 0 || math.IsNaN(seconds) || math.IsInf(seconds, 0) {
+		return 0, false
+	}
+	if seconds > maxMeaningfulETA.Seconds() {
+		return 0, false
+	}
+
+	return time.Duration(seconds * float64(time.Second)), true
+}

--- a/internal/doctor/eta_test.go
+++ b/internal/doctor/eta_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package doctor
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestETAFromSecondsPreservesSubSecondPrecision(t *testing.T) {
+	eta, ok := etaFromSeconds(0.25)
+	if !ok {
+		t.Fatal("expected 250ms ETA to be meaningful")
+	}
+	if eta != 250*time.Millisecond {
+		t.Fatalf("expected 250ms ETA, got %s", eta)
+	}
+}
+
+func TestETAFromSecondsRejectsUnmeaningfulValues(t *testing.T) {
+	tests := []float64{
+		0,
+		-1,
+		math.NaN(),
+		math.Inf(1),
+		maxMeaningfulETA.Seconds() + 1,
+	}
+
+	for _, seconds := range tests {
+		if eta, ok := etaFromSeconds(seconds); ok {
+			t.Fatalf("expected %v seconds to be rejected, got ETA %s", seconds, eta)
+		}
+	}
+}

--- a/internal/doctor/predict.go
+++ b/internal/doctor/predict.go
@@ -109,7 +109,10 @@ func predictFDExhaustion(snapshots []*collector.Signals) []Prediction {
 	}
 
 	etaSecs := remaining / avgRate
-	eta := time.Duration(etaSecs) * time.Second
+	eta, ok := etaFromSeconds(etaSecs)
+	if !ok {
+		return nil
+	}
 
 	// Confidence based on consistency of growth rate.
 	confidence := rateConsistency(rates)
@@ -162,7 +165,10 @@ func predictDiskSaturation(snapshots []*collector.Signals) []Prediction {
 	}
 
 	etaSecs := remaining / slopePerSec
-	eta := time.Duration(etaSecs) * time.Second
+	eta, ok := etaFromSeconds(etaSecs)
+	if !ok {
+		return nil
+	}
 
 	confidence := rateConsistency(latencies) * 0.8 // Lower confidence for latency trends.
 
@@ -211,7 +217,10 @@ func predictSchedDegradation(snapshots []*collector.Signals) []Prediction {
 	}
 
 	etaSecs := remaining / slopePerSec
-	eta := time.Duration(etaSecs) * time.Second
+	eta, ok := etaFromSeconds(etaSecs)
+	if !ok {
+		return nil
+	}
 
 	confidence := rateConsistency(delays) * 0.7
 
@@ -260,7 +269,10 @@ func predictTCPDegradation(snapshots []*collector.Signals) []Prediction {
 	}
 
 	etaSecs := remaining / slopePerSec
-	eta := time.Duration(etaSecs) * time.Second
+	eta, ok := etaFromSeconds(etaSecs)
+	if !ok {
+		return nil
+	}
 
 	confidence := rateConsistency(rates) * 0.75
 

--- a/internal/doctor/predict_test.go
+++ b/internal/doctor/predict_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package doctor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/optiqor/kerno/internal/collector"
+)
+
+func TestPredictFDExhaustionPreservesSubSecondETA(t *testing.T) {
+	now := time.Now()
+	snapshots := []*collector.Signals{
+		{
+			Timestamp: now,
+			FD: &collector.FDSnapshot{
+				GrowthRate: 4,
+				NetDelta:   65535,
+			},
+		},
+		{
+			Timestamp: now.Add(time.Second),
+			FD: &collector.FDSnapshot{
+				GrowthRate: 4,
+				NetDelta:   65535,
+			},
+		},
+	}
+
+	predictions := predictFDExhaustion(snapshots)
+	if len(predictions) != 1 {
+		t.Fatalf("expected one FD exhaustion prediction, got %d", len(predictions))
+	}
+	if predictions[0].TimeToImpact != 250*time.Millisecond {
+		t.Fatalf("expected 250ms ETA, got %s", predictions[0].TimeToImpact)
+	}
+}
+
+func TestPredictFDExhaustionRejectsUnmeaningfulETA(t *testing.T) {
+	now := time.Now()
+	snapshots := []*collector.Signals{
+		{
+			Timestamp: now,
+			FD: &collector.FDSnapshot{
+				GrowthRate: 0.01,
+			},
+		},
+		{
+			Timestamp: now.Add(time.Second),
+			FD: &collector.FDSnapshot{
+				GrowthRate: 0.01,
+			},
+		},
+	}
+
+	predictions := predictFDExhaustion(snapshots)
+	if len(predictions) != 0 {
+		t.Fatalf("expected no prediction for ETA beyond meaningful window, got %d", len(predictions))
+	}
+}

--- a/internal/doctor/rules.go
+++ b/internal/doctor/rules.go
@@ -274,9 +274,10 @@ func evalFDLeak(s *collector.Signals, t config.DoctorThresholds) []Finding {
 		remainingFDs := 65536.0 - float64(s.FD.NetDelta)
 		if remainingFDs > 0 {
 			etaSecs := remainingFDs / s.FD.GrowthRate
-			eta := time.Duration(etaSecs) * time.Second
-			f.ETA = &eta
-			f.Impact = fmt.Sprintf("Process will hit ulimit (65536) in %s at current growth rate", f.ETAString())
+			if eta, ok := etaFromSeconds(etaSecs); ok {
+				f.ETA = &eta
+				f.Impact = fmt.Sprintf("Process will hit ulimit (65536) in %s at current growth rate", f.ETAString())
+			}
 		}
 	}
 
@@ -416,9 +417,10 @@ func evalOOMImminent(s *collector.Signals, t config.DoctorThresholds) []Finding 
 	// Estimate time to 100% if growing.
 	if s.Memory.GrowthRateBytesPerSec > 0 && s.Memory.AvailableBytes > 0 {
 		etaSecs := float64(s.Memory.AvailableBytes) / s.Memory.GrowthRateBytesPerSec
-		eta := time.Duration(etaSecs) * time.Second
-		f.ETA = &eta
-		f.Impact = fmt.Sprintf("At current growth rate, memory will be exhausted in %s", f.ETAString())
+		if eta, ok := etaFromSeconds(etaSecs); ok {
+			f.ETA = &eta
+			f.Impact = fmt.Sprintf("At current growth rate, memory will be exhausted in %s", f.ETAString())
+		}
 	}
 
 	return []Finding{f}
@@ -562,13 +564,14 @@ func evalMemoryLimitPressure(s *collector.Signals) []Finding {
 			if c.GrowthRateBytesPerSec >= minGrowthForETA && c.LimitBytes > c.CurrentBytes {
 				remaining := c.LimitBytes - c.CurrentBytes
 				etaSecs := float64(remaining) / c.GrowthRateBytesPerSec
-				eta := time.Duration(etaSecs) * time.Second
-				f.ETA = &eta
-				f.Impact = fmt.Sprintf(
-					"%s is %.0f%% of its memory limit (%s / %s) and growing %.1f MB/s. OOMKill expected in %s.",
-					label, c.UsedPct,
-					formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes),
-					growthMBs, f.ETAString())
+				if eta, ok := etaFromSeconds(etaSecs); ok {
+					f.ETA = &eta
+					f.Impact = fmt.Sprintf(
+						"%s is %.0f%% of its memory limit (%s / %s) and growing %.1f MB/s. OOMKill expected in %s.",
+						label, c.UsedPct,
+						formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes),
+						growthMBs, f.ETAString())
+				}
 			} else {
 				f.Impact = fmt.Sprintf(
 					"%s is %.0f%% of its memory limit (%s / %s) and trending up, but no reliable ETA available (growth rate < 1 MB/s).",

--- a/internal/doctor/rules_test.go
+++ b/internal/doctor/rules_test.go
@@ -218,6 +218,31 @@ func TestEvaluate_FDLeak(t *testing.T) {
 	}
 }
 
+func TestEvaluate_FDLeakSkipsUnmeaningfulETA(t *testing.T) {
+	thresholds := defaultThresholds()
+	thresholds.FDGrowthPerSec = 0.001
+	signals := &collector.Signals{
+		FD: &collector.FDSnapshot{
+			GrowthRate: 0.01,
+			NetDelta:   100,
+		},
+	}
+
+	findings := Evaluate(signals, thresholds)
+	for _, f := range findings {
+		if f.Rule == "fd_leak" {
+			if f.ETA != nil {
+				t.Fatalf("expected no ETA for far-future FD leak, got %s", *f.ETA)
+			}
+			if f.Impact != "Process will eventually hit ulimit and crash" {
+				t.Fatalf("expected default impact when ETA is unmeaningful, got %q", f.Impact)
+			}
+			return
+		}
+	}
+	t.Fatal("expected fd_leak finding")
+}
+
 func TestEvaluate_SyscallLatencyHigh(t *testing.T) {
 	signals := &collector.Signals{
 		Syscall: &collector.SyscallSnapshot{
@@ -363,6 +388,32 @@ func TestEvaluate_OOMImminent_Critical(t *testing.T) {
 	if !found {
 		t.Error("expected CRITICAL oom_imminent finding for 96.9% + growing")
 	}
+}
+
+func TestEvaluate_OOMImminentSkipsUnmeaningfulETA(t *testing.T) {
+	signals := &collector.Signals{
+		Memory: &collector.MemorySnapshot{
+			TotalBytes:            16_000_000_000,
+			UsedBytes:             15_500_000_000,
+			UsedPct:               96.9,
+			GrowthRateBytesPerSec: 100,
+			AvailableBytes:        1_000_000_000,
+		},
+	}
+
+	findings := Evaluate(signals, defaultThresholds())
+	for _, f := range findings {
+		if f.Rule == "oom_imminent" {
+			if f.ETA != nil {
+				t.Fatalf("expected no ETA for far-future OOM risk, got %s", *f.ETA)
+			}
+			if f.Impact != "OOM killer will start terminating processes if memory is not freed" {
+				t.Fatalf("expected default impact when ETA is unmeaningful, got %q", f.Impact)
+			}
+			return
+		}
+	}
+	t.Fatal("expected oom_imminent finding")
 }
 
 func TestEvaluate_OOMImminent_BelowThreshold(t *testing.T) {


### PR DESCRIPTION
## What

Clamp doctor ETA conversion through a shared helper so tiny positive slopes no longer produce overflow-prone or misleading durations, while preserving sub-second precision for real near-term ETAs.

## Why

Fixes #125

## How

- Adds `etaFromSeconds` to reject invalid or far-future ETAs beyond the meaningful prediction window.
- Uses the helper in doctor predictions for FD, disk, scheduler, and TCP trends.
- Uses the helper in doctor findings for FD leak, OOM risk, and cgroup memory pressure ETAs so base findings stay intact when ETA is not meaningful.
- Adds regression tests for sub-second ETA precision and far-future ETA suppression.

## Testing

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes
- [x] Tested locally with: `go test ./internal/doctor`

Local notes:
- `go test ./internal/doctor` passes.
- `go test ./...` is blocked on this macOS environment by an existing build error outside this patch: `internal/chaos/cpu.go:95:14: undefined: unix.Nanosleep`.

<!-- Required for changes touching internal/bpf/, internal/collector/, internal/doctor/. -->

- [ ] N/A — pure docs/refactor
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed
- [x] Added/updated tests for new code paths
- [x] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`
