### PR TITLE
fix(chaos): update isResourceExhausted to check exact syscall error code

### DIFF
--- a/internal/chaos/fd.go
+++ b/internal/chaos/fd.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"syscall"
 	"time"
 )
 
@@ -83,14 +84,7 @@ func fdRateFromIntensity(intensity Intensity) int {
 // isResourceExhausted detects EMFILE / ENFILE / ENOSPC so the scenario
 // can stop gracefully rather than treating ulimit-hits as fatal errors.
 func isResourceExhausted(err error) bool {
-	if err == nil {
-		return false
-	}
-	// Walk the error chain for syscall errno equivalents.
-	var pErr *os.PathError
-	if errors.As(err, &pErr) {
-		s := pErr.Err.Error()
-		return s == "too many open files" || s == "no space left on device"
-	}
-	return false
+	return errors.Is(err, syscall.EMFILE) ||
+		errors.Is(err, syscall.ENFILE) ||
+		errors.Is(err, syscall.ENOSPC)
 }


### PR DESCRIPTION
## What
Refactored the `isResourceExhausted` function in the `chaos` package to check for exact syscall error codes instead of relying on localized English error strings.


## Why
Fixes #127


## How
Replaced string-matching logic with `errors.Is()` alongside `syscall.EMFILE`, `syscall.ENFILE`, and `syscall.ENOSPC`. This ensures the error handling remains robust and language-agnostic across different operating systems.


#Test
GitHub Action to test and not used "make"