### PR TITLE
fix: clamp doctor ETA conversions

### DIFF
--- a/internal/doctor/eta.go
+++ b/internal/doctor/eta.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package doctor
+
+import (
+	"math"
+	"time"
+)
+
+const maxMeaningfulETA = 7 * 24 * time.Hour
+
+// etaDuration converts seconds to a duration without truncating useful
+// sub-second precision and rejects values too large to be actionable.
+func etaDuration(etaSecs float64) (time.Duration, bool) {
+	if etaSecs <= 0 || math.IsNaN(etaSecs) || math.IsInf(etaSecs, 0) {
+		return 0, false
+	}
+
+	eta := time.Duration(etaSecs * float64(time.Second))
+	if eta <= 0 || eta > maxMeaningfulETA {
+		return 0, false
+	}
+
+	return eta, true
+}

--- a/internal/doctor/eta_test.go
+++ b/internal/doctor/eta_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package doctor
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestETADurationPreservesSubSecondPrecision(t *testing.T) {
+	eta, ok := etaDuration(0.25)
+	if !ok {
+		t.Fatal("expected sub-second ETA to be meaningful")
+	}
+	if eta != 250*time.Millisecond {
+		t.Fatalf("expected 250ms, got %s", eta)
+	}
+}
+
+func TestETADurationRejectsNonMeaningfulValues(t *testing.T) {
+	tests := []struct {
+		name string
+		secs float64
+	}{
+		{name: "zero", secs: 0},
+		{name: "negative", secs: -1},
+		{name: "nan", secs: math.NaN()},
+		{name: "infinity", secs: math.Inf(1)},
+		{name: "beyond ceiling", secs: maxMeaningfulETA.Seconds() + 1},
+		{name: "overflow scale", secs: math.MaxFloat64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if eta, ok := etaDuration(tt.secs); ok {
+				t.Fatalf("expected ETA to be rejected, got %s", eta)
+			}
+		})
+	}
+}
+
+func TestETADurationAcceptsCeiling(t *testing.T) {
+	eta, ok := etaDuration(maxMeaningfulETA.Seconds())
+	if !ok {
+		t.Fatal("expected ceiling ETA to be meaningful")
+	}
+	if eta != maxMeaningfulETA {
+		t.Fatalf("expected %s, got %s", maxMeaningfulETA, eta)
+	}
+}

--- a/internal/doctor/predict.go
+++ b/internal/doctor/predict.go
@@ -109,7 +109,10 @@ func predictFDExhaustion(snapshots []*collector.Signals) []Prediction {
 	}
 
 	etaSecs := remaining / avgRate
-	eta := time.Duration(etaSecs) * time.Second
+	eta, ok := etaDuration(etaSecs)
+	if !ok {
+		return nil
+	}
 
 	// Confidence based on consistency of growth rate.
 	confidence := rateConsistency(rates)
@@ -162,7 +165,10 @@ func predictDiskSaturation(snapshots []*collector.Signals) []Prediction {
 	}
 
 	etaSecs := remaining / slopePerSec
-	eta := time.Duration(etaSecs) * time.Second
+	eta, ok := etaDuration(etaSecs)
+	if !ok {
+		return nil
+	}
 
 	confidence := rateConsistency(latencies) * 0.8 // Lower confidence for latency trends.
 
@@ -211,7 +217,10 @@ func predictSchedDegradation(snapshots []*collector.Signals) []Prediction {
 	}
 
 	etaSecs := remaining / slopePerSec
-	eta := time.Duration(etaSecs) * time.Second
+	eta, ok := etaDuration(etaSecs)
+	if !ok {
+		return nil
+	}
 
 	confidence := rateConsistency(delays) * 0.7
 
@@ -260,7 +269,10 @@ func predictTCPDegradation(snapshots []*collector.Signals) []Prediction {
 	}
 
 	etaSecs := remaining / slopePerSec
-	eta := time.Duration(etaSecs) * time.Second
+	eta, ok := etaDuration(etaSecs)
+	if !ok {
+		return nil
+	}
 
 	confidence := rateConsistency(rates) * 0.75
 

--- a/internal/doctor/rules.go
+++ b/internal/doctor/rules.go
@@ -274,9 +274,10 @@ func evalFDLeak(s *collector.Signals, t config.DoctorThresholds) []Finding {
 		remainingFDs := 65536.0 - float64(s.FD.NetDelta)
 		if remainingFDs > 0 {
 			etaSecs := remainingFDs / s.FD.GrowthRate
-			eta := time.Duration(etaSecs) * time.Second
-			f.ETA = &eta
-			f.Impact = fmt.Sprintf("Process will hit ulimit (65536) in %s at current growth rate", f.ETAString())
+			if eta, ok := etaDuration(etaSecs); ok {
+				f.ETA = &eta
+				f.Impact = fmt.Sprintf("Process will hit ulimit (65536) in %s at current growth rate", f.ETAString())
+			}
 		}
 	}
 
@@ -416,9 +417,10 @@ func evalOOMImminent(s *collector.Signals, t config.DoctorThresholds) []Finding 
 	// Estimate time to 100% if growing.
 	if s.Memory.GrowthRateBytesPerSec > 0 && s.Memory.AvailableBytes > 0 {
 		etaSecs := float64(s.Memory.AvailableBytes) / s.Memory.GrowthRateBytesPerSec
-		eta := time.Duration(etaSecs) * time.Second
-		f.ETA = &eta
-		f.Impact = fmt.Sprintf("At current growth rate, memory will be exhausted in %s", f.ETAString())
+		if eta, ok := etaDuration(etaSecs); ok {
+			f.ETA = &eta
+			f.Impact = fmt.Sprintf("At current growth rate, memory will be exhausted in %s", f.ETAString())
+		}
 	}
 
 	return []Finding{f}
@@ -562,13 +564,18 @@ func evalMemoryLimitPressure(s *collector.Signals) []Finding {
 			if c.GrowthRateBytesPerSec >= minGrowthForETA && c.LimitBytes > c.CurrentBytes {
 				remaining := c.LimitBytes - c.CurrentBytes
 				etaSecs := float64(remaining) / c.GrowthRateBytesPerSec
-				eta := time.Duration(etaSecs) * time.Second
-				f.ETA = &eta
-				f.Impact = fmt.Sprintf(
-					"%s is %.0f%% of its memory limit (%s / %s) and growing %.1f MB/s. OOMKill expected in %s.",
-					label, c.UsedPct,
-					formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes),
-					growthMBs, f.ETAString())
+				if eta, ok := etaDuration(etaSecs); ok {
+					f.ETA = &eta
+					f.Impact = fmt.Sprintf(
+						"%s is %.0f%% of its memory limit (%s / %s) and growing %.1f MB/s. OOMKill expected in %s.",
+						label, c.UsedPct,
+						formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes),
+						growthMBs, f.ETAString())
+				} else {
+					f.Impact = fmt.Sprintf(
+						"%s is %.0f%% of its memory limit (%s / %s) and trending up, but no reliable ETA available.",
+						label, c.UsedPct, formatBytes(c.CurrentBytes), formatBytes(c.LimitBytes))
+				}
 			} else {
 				f.Impact = fmt.Sprintf(
 					"%s is %.0f%% of its memory limit (%s / %s) and trending up, but no reliable ETA available (growth rate < 1 MB/s).",


### PR DESCRIPTION
## Summary
- add a shared ETA conversion helper that preserves sub-second precision
- reject non-finite, negative, overflowed, or non-actionably large ETAs instead of producing nonsense durations
- apply the helper to doctor prediction/rule ETA paths and cover the helper with focused tests

Fixes #125

## Testing
- `go test internal\doctor\eta.go internal\doctor\eta_test.go`
- `GOOS=linux GOARCH=amd64 go test -c ./internal/doctor -o D:\codex-tools\gotmp\doctor.test`

Note: full package tests could not be executed locally because this Windows environment cannot run the generated Linux test binary; Linux compile for the doctor package succeeds and CI should run the full suite.