### PR TITLE
fix: align TCPEvent with BTF tcp_event layout

### DIFF
--- a/internal/bpf/c/headers/kerno.h
+++ b/internal/bpf/c/headers/kerno.h
@@ -72,6 +72,7 @@ struct tcp_event {
     __u32 rtt_us;      // smoothed RTT in microseconds (for RTT events)
     __u32 retransmits; // total retransmit count
     char  comm[TASK_COMM_LEN];
+    __u8 _pad[4];
 };
 
 // ─── OOM Kill Event ────────────────────────────────────────────────────────

--- a/internal/bpf/events.go
+++ b/internal/bpf/events.go
@@ -84,6 +84,7 @@ type TCPEvent struct {
 	RTTUs       uint32
 	Retransmits uint32
 	Comm        [TaskCommLen]byte
+	Pad         [4]byte
 }
 
 // CommString returns the process name as a Go string.


### PR DESCRIPTION
## Summary

Align `TCPEvent` with the kernel `tcp_event` struct layout by adding the missing 4-byte tail padding field.

## Changes Made

* Added `_pad[4]` to `struct tcp_event` in `internal/bpf/c/headers/kerno.h`
* Added `Pad [4]byte` to `TCPEvent` in `internal/bpf/events.go`
* Ensured the Go struct mirrors the kernel/BTF layout byte-for-byte
* Prevented potential future field misalignment if fields are added after `comm`

## Why

The kernel `tcp_event` struct is 64 bytes because it includes 4 bytes of trailing padding for alignment, while the Go `TCPEvent` struct was only 60 bytes. Although current parsing works because all active fields precede the padding, the layouts were not identical.

This change keeps the Go and kernel representations consistent and matches the pattern used by the other event structures.

close #116 