### PR TITLE
test(metrics): finish table-driving bridge_test.go

### DIFF
--- a/internal/metrics/bridge_test.go
+++ b/internal/metrics/bridge_test.go
@@ -148,7 +148,7 @@ func TestRecordOOM(t *testing.T) {
 func TestRecordFD(t *testing.T) {
 	tests := []struct {
 		name string
-		op   uint8
+		op   bpf.FDOp
 	}{
 		{
 			name: "fd_open",
@@ -207,9 +207,9 @@ func TestRecordSchedDelay(t *testing.T) {
 
 func TestCardinalityLimit(t *testing.T) {
 	tests := []struct {
-		name      string
-		calls     int
-		wantLast  bool
+		name     string
+		calls    int
+		wantLast bool
 	}{
 		{
 			name:     "at_limit",

--- a/internal/metrics/bridge_test.go
+++ b/internal/metrics/bridge_test.go
@@ -14,135 +14,261 @@ import (
 )
 
 func TestRecordSyscall(t *testing.T) {
-	b := NewBridge(slog.Default())
-
-	// Build a raw SyscallEvent.
-	event := bpf.SyscallEvent{
-		LatencyNs: 5_000_000,
-		PID:       1234,
-		SyscallNr: 1, // write
+	tests := []struct {
+		name       string
+		syscallNr  uint32
+		syscallStr string
+		comm       string
+	}{
+		{
+			name:       "write_syscall",
+			syscallNr:  1,
+			syscallStr: "write",
+			comm:       "nginx",
+		},
 	}
-	copy(event.Comm[:], "nginx")
-	data := encodeSyscallEvent(&event)
 
-	before := testutil.ToFloat64(SyscallTotal.WithLabelValues("write", "nginx"))
-	b.recordSyscall(bpf.RawEvent{Data: data})
-	after := testutil.ToFloat64(SyscallTotal.WithLabelValues("write", "nginx"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBridge(slog.Default())
 
-	if got := after - before; got != 1 {
-		t.Errorf("SyscallTotal delta = %v, want 1", got)
+			event := bpf.SyscallEvent{
+				LatencyNs: 5_000_000,
+				PID:       1234,
+				SyscallNr: tt.syscallNr,
+			}
+			copy(event.Comm[:], tt.comm)
+			data := encodeSyscallEvent(&event)
+
+			before := testutil.ToFloat64(
+				SyscallTotal.WithLabelValues(tt.syscallStr, tt.comm),
+			)
+
+			b.recordSyscall(bpf.RawEvent{Data: data})
+
+			after := testutil.ToFloat64(
+				SyscallTotal.WithLabelValues(tt.syscallStr, tt.comm),
+			)
+
+			if got := after - before; got != 1 {
+				t.Errorf("SyscallTotal delta = %v, want 1", got)
+			}
+		})
 	}
 }
 
 func TestRecordDiskIO(t *testing.T) {
-	b := NewBridge(slog.Default())
-
-	event := bpf.DiskEvent{
-		LatencyNs: 250_000,
-		Dev:       8 << 20, // 8:0
-		NrBytes:   4096,
-		Op:        'W',
+	tests := []struct {
+		name     string
+		dev      uint32
+		devLabel string
+		op       byte
+		opLabel  string
+		bytes    uint32
+	}{
+		{
+			name:     "disk_write",
+			dev:      8 << 20,
+			devLabel: "8:0",
+			op:       'W',
+			opLabel:  "write",
+			bytes:    4096,
+		},
 	}
-	copy(event.Comm[:], "postgres")
-	data := encodeDiskEvent(&event)
 
-	before := testutil.ToFloat64(DiskIOBytesTotal.WithLabelValues("8:0", "write"))
-	b.recordDiskIO(bpf.RawEvent{Data: data})
-	after := testutil.ToFloat64(DiskIOBytesTotal.WithLabelValues("8:0", "write"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBridge(slog.Default())
 
-	if got := after - before; got != 4096 {
-		t.Errorf("DiskIOBytesTotal delta = %v, want 4096", got)
+			event := bpf.DiskEvent{
+				LatencyNs: 250_000,
+				Dev:       tt.dev,
+				NrBytes:   tt.bytes,
+				Op:        tt.op,
+			}
+			copy(event.Comm[:], "postgres")
+			data := encodeDiskEvent(&event)
+
+			before := testutil.ToFloat64(
+				DiskIOBytesTotal.WithLabelValues(tt.devLabel, tt.opLabel),
+			)
+
+			b.recordDiskIO(bpf.RawEvent{Data: data})
+
+			after := testutil.ToFloat64(
+				DiskIOBytesTotal.WithLabelValues(tt.devLabel, tt.opLabel),
+			)
+
+			if got := after - before; got != float64(tt.bytes) {
+				t.Errorf("DiskIOBytesTotal delta = %v, want %d", got, tt.bytes)
+			}
+		})
 	}
 }
 
 func TestRecordOOM(t *testing.T) {
-	b := NewBridge(slog.Default())
-
-	event := bpf.OOMEvent{
-		PID:      1234,
-		OOMScore: 950,
+	tests := []struct {
+		name string
+		comm string
+	}{
+		{
+			name: "oom_kill",
+			comm: "oom-victim",
+		},
 	}
-	copy(event.Comm[:], "oom-victim")
-	data := encodeOOMEvent(&event)
 
-	before := testutil.ToFloat64(OOMKillsTotal.WithLabelValues("oom-victim"))
-	b.recordOOM(bpf.RawEvent{Data: data})
-	after := testutil.ToFloat64(OOMKillsTotal.WithLabelValues("oom-victim"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBridge(slog.Default())
 
-	if got := after - before; got != 1 {
-		t.Errorf("OOMKillsTotal delta = %v, want 1", got)
+			event := bpf.OOMEvent{
+				PID:      1234,
+				OOMScore: 950,
+			}
+			copy(event.Comm[:], tt.comm)
+			data := encodeOOMEvent(&event)
+
+			before := testutil.ToFloat64(
+				OOMKillsTotal.WithLabelValues(tt.comm),
+			)
+
+			b.recordOOM(bpf.RawEvent{Data: data})
+
+			after := testutil.ToFloat64(
+				OOMKillsTotal.WithLabelValues(tt.comm),
+			)
+
+			if got := after - before; got != 1 {
+				t.Errorf("OOMKillsTotal delta = %v, want 1", got)
+			}
+		})
 	}
 }
 
 func TestRecordFD(t *testing.T) {
-	b := NewBridge(slog.Default())
-
-	event := bpf.FDEvent{
-		PID: 5678,
-		FD:  42,
-		Op:  bpf.FDOpOpen,
+	tests := []struct {
+		name string
+		op   uint8
+	}{
+		{
+			name: "fd_open",
+			op:   bpf.FDOpOpen,
+		},
 	}
-	copy(event.Comm[:], "leaky")
-	data := encodeFDEvent(&event)
 
-	before := testutil.ToFloat64(FDOpenTotal.WithLabelValues("leaky"))
-	b.recordFD(bpf.RawEvent{Data: data})
-	after := testutil.ToFloat64(FDOpenTotal.WithLabelValues("leaky"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBridge(slog.Default())
 
-	if got := after - before; got != 1 {
-		t.Errorf("FDOpenTotal delta = %v, want 1", got)
+			event := bpf.FDEvent{
+				PID: 5678,
+				FD:  42,
+				Op:  tt.op,
+			}
+			copy(event.Comm[:], "leaky")
+			data := encodeFDEvent(&event)
+
+			before := testutil.ToFloat64(FDOpenTotal.WithLabelValues("leaky"))
+			b.recordFD(bpf.RawEvent{Data: data})
+			after := testutil.ToFloat64(FDOpenTotal.WithLabelValues("leaky"))
+
+			if got := after - before; got != 1 {
+				t.Errorf("FDOpenTotal delta = %v, want 1", got)
+			}
+		})
 	}
 }
 
 func TestRecordSchedDelay(t *testing.T) {
-	b := NewBridge(slog.Default())
-
-	event := bpf.SchedEvent{
-		RunqDelayNs: 15_000_000,
-		PID:         999,
-		CPU:         3,
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "sched_delay_observe",
+		},
 	}
-	copy(event.Comm[:], "java")
-	data := encodeSchedEvent(&event)
 
-	// Just verify no panic/error — summary observation can't easily be read back.
-	b.recordSchedDelay(bpf.RawEvent{Data: data})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBridge(slog.Default())
+
+			event := bpf.SchedEvent{
+				RunqDelayNs: 15_000_000,
+				PID:         999,
+				CPU:         3,
+			}
+			copy(event.Comm[:], "java")
+			data := encodeSchedEvent(&event)
+
+			b.recordSchedDelay(bpf.RawEvent{Data: data})
+		})
+	}
 }
 
 func TestCardinalityLimit(t *testing.T) {
-	b := NewBridge(slog.Default())
+	tests := []struct {
+		name      string
+		calls     int
+		wantLast  bool
+	}{
+		{
+			name:     "at_limit",
+			calls:    LabelCardinalityLimit,
+			wantLast: true,
+		},
+		{
+			name:     "one_past_limit",
+			calls:    LabelCardinalityLimit + 1,
+			wantLast: false,
+		},
+	}
 
-	// Exhaust the cardinality limit for a metric.
-	for i := 0; i < LabelCardinalityLimit; i++ {
-		if !b.cardinalityOK("test_metric") {
-			t.Fatalf("cardinalityOK returned false at i=%d, expected true", i)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBridge(slog.Default())
+
+			var got bool
+			for i := 0; i < tt.calls; i++ {
+				got = b.cardinalityOK("test_metric")
+			}
+
+			if got != tt.wantLast {
+				t.Fatalf("last cardinalityOK() = %v, want %v", got, tt.wantLast)
+			}
+		})
+	}
+
+	t.Run("different_metric_still_allowed", func(t *testing.T) {
+		b := NewBridge(slog.Default())
+
+		for i := 0; i < LabelCardinalityLimit+1; i++ {
+			b.cardinalityOK("test_metric")
 		}
-	}
 
-	// Next one should be rejected.
-	if b.cardinalityOK("test_metric") {
-		t.Error("expected cardinalityOK to return false after limit")
-	}
-
-	// Different metric should still be ok.
-	if !b.cardinalityOK("other_metric") {
-		t.Error("expected cardinalityOK to return true for different metric")
-	}
+		if !b.cardinalityOK("other_metric") {
+			t.Error("expected cardinalityOK to return true for different metric")
+		}
+	})
 }
 
 func TestFormatDev(t *testing.T) {
 	tests := []struct {
+		name string
 		dev  uint32
 		want string
 	}{
-		{8<<20 | 0, "8:0"},
-		{8<<20 | 1, "8:1"},
-		{259<<20 | 0, "259:0"},
+		{"8:0", 8<<20 | 0, "8:0"},
+		{"8:1", 8<<20 | 1, "8:1"},
+		{"259:0", 259<<20 | 0, "259:0"},
+		{"259:1", 259<<20 | 1, "259:1"},
 	}
+
 	for _, tt := range tests {
-		if got := formatDev(tt.dev); got != tt.want {
-			t.Errorf("formatDev(%d) = %q, want %q", tt.dev, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatDev(tt.dev); got != tt.want {
+				t.Errorf("formatDev(%d) = %q, want %q", tt.dev, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Kerno! A few notes:

- PR title must follow Conventional Commits: `feat(scope): subject` (linted in CI).
- Every commit must be DCO-signed (`git commit -s`).
- Squash merges are the default — your PR title becomes the merge commit.
- CI runs build + race tests + lint + (when configured) the kernel matrix.
-->

## What

<!-- 1–2 sentences. What does this PR change? -->
Convert the remaining tests in internal/metrics/bridge_test.go to table-driven tests using tests := []struct{...} and t.Run. Also add explicit cardinality boundary coverage and expand device-number formatting coverage.

## Why

<!-- Link the issue. -->
Fixes #141 

## How

<!-- Notable design decisions, tradeoffs, or implementation notes. Keep it short. -->
• Converted record-path tests (syscall, disk_io, oom, fd, and sched) to table-driven tests.
• Added explicit cardinality boundary cases for:
    • at limit
    • one past limit
• Expanded formatDev coverage with additional device-number formatting cases.
• Followed the table-driven style used in internal/cli/trace_test.go.
• Preserved existing test behavior and avoided t.Parallel() because the tests share global metric registries.

## Testing

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] Tested locally with: <!-- e.g. `sudo ./bin/kerno doctor --duration 5s` -->

<!-- Required for changes touching internal/bpf/, internal/collector/, internal/doctor/. -->

- [x] N/A — pure docs/refactor
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [ ] Documentation updated where user-visible behavior changed
- [x] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`
