### PR TITLE
fix: remove misleading error prefix for exit-code

### DIFF
--- a/cmd/kerno/main.go
+++ b/cmd/kerno/main.go
@@ -21,7 +21,6 @@ import (
 
 func main() {
 	if err := cli.New().Execute(); err != nil {
-
 		type exitCoder interface {
 			ExitCode() int
 		}

--- a/cmd/kerno/main.go
+++ b/cmd/kerno/main.go
@@ -21,7 +21,16 @@ import (
 
 func main() {
 	if err := cli.New().Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+
+		type exitCoder interface {
+			ExitCode() int
+		}
+
+		if exitErr, ok := err.(exitCoder); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/kerno/main.go
+++ b/cmd/kerno/main.go
@@ -21,7 +21,7 @@ import (
 
 func main() {
 	if err := cli.New().Execute(); err != nil {
-	fmt.Fprintln(os.Stderr, err)
-	os.Exit(1)
-}
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/cmd/kerno/main.go
+++ b/cmd/kerno/main.go
@@ -21,7 +21,7 @@ import (
 
 func main() {
 	if err := cli.New().Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}
 }


### PR DESCRIPTION
Removed the misleading `"Error:"` prefix from CLI output when using `--exit-code`.

This ensures expected critical findings are displayed cleanly without being framed as unexpected errors.

Fixes #122
