### PR TITLE
test(doctor): add oom kill integration coverage

### DIFF
--- a/internal/integration/oom_kill_test.go
+++ b/internal/integration/oom_kill_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/optiqor/kerno/internal/collector"
+	"github.com/optiqor/kerno/internal/config"
+	"github.com/optiqor/kerno/internal/doctor"
+)
+
+func TestOOMKillFindingFromCapturedSnapshot(t *testing.T) {
+	signals := &collector.Signals{
+		Timestamp: time.Now(),
+		Duration:  30 * time.Second,
+		OOM: &collector.OOMSnapshot{
+			Events: []collector.OOMEventEntry{
+				{
+					PID:        1234,
+					Comm:       "oom-victim",
+					OOMScore:   900,
+					RSSPages:   100000,
+					TotalPages: 110000,
+				},
+			},
+			Count: 1,
+		},
+	}
+
+	findings := doctor.Evaluate(signals, config.Default().Doctor.Thresholds)
+
+	found := false
+	for _, finding := range findings {
+		if finding.Rule == "oom_kill_occurred" && finding.Severity == doctor.SeverityCritical {
+			found = true
+			if finding.Process != "oom-victim" {
+				t.Fatalf("expected process oom-victim, got %q", finding.Process)
+			}
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected oom_kill_occurred finding, got %#v", findings)
+	}
+}

--- a/internal/integration/oom_kill_test.go
+++ b/internal/integration/oom_kill_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/optiqor/kerno/internal/bpf"
 	"github.com/optiqor/kerno/internal/collector"
 	"github.com/optiqor/kerno/internal/config"
@@ -49,16 +48,12 @@ func TestOOMKillCapturedFromConstrainedCgroup(t *testing.T) {
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image: "docker.io/library/python:3.12-alpine",
 			Cmd: []string{
-				"python3",
+				"sh",
 				"-c",
-				"chunks=[]\nwhile True:\n chunks.append(bytearray(8*1024*1024))\n",
+				"ulimit -v 65536; python3 -c 'chunks=[]\nwhile True:\n chunks.append(bytearray(8*1024*1024))'",
 			},
 			WaitingFor:      wait.ForExit().WithExitTimeout(45 * time.Second),
 			AlwaysPullImage: false,
-			HostConfigModifier: func(hostConfig *dockercontainer.HostConfig) {
-				hostConfig.Memory = 64 * 1024 * 1024
-				hostConfig.MemorySwap = 64 * 1024 * 1024
-			},
 		},
 		Started: true,
 	})
@@ -77,11 +72,13 @@ func TestOOMKillCapturedFromConstrainedCgroup(t *testing.T) {
 
 	for time.Now().Before(deadline) {
 		got := oomCollector.Snapshot()
+
 		var ok bool
 		snap, ok = got.(*collector.OOMSnapshot)
 		if ok && snap.Count > 0 {
 			break
 		}
+
 		time.Sleep(250 * time.Millisecond)
 	}
 
@@ -97,10 +94,10 @@ func TestOOMKillCapturedFromConstrainedCgroup(t *testing.T) {
 			break
 		}
 	}
+
 	if captured == nil {
 		t.Fatalf("expected captured OOM event for victim process, got %#v", snap.Events)
 	}
-
 	if captured.PID == 0 {
 		t.Fatalf("expected captured OOM event PID to be set, got %#v", captured)
 	}

--- a/internal/integration/oom_kill_test.go
+++ b/internal/integration/oom_kill_test.go
@@ -6,46 +6,121 @@
 package integration
 
 import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/optiqor/kerno/internal/bpf"
 	"github.com/optiqor/kerno/internal/collector"
 	"github.com/optiqor/kerno/internal/config"
 	"github.com/optiqor/kerno/internal/doctor"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-func TestOOMKillFindingFromCapturedSnapshot(t *testing.T) {
+func TestOOMKillCapturedFromConstrainedCgroup(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	loader := bpf.NewOOMTrackLoader(logger)
+	closer, err := loader.Load()
+	if err != nil {
+		t.Skipf("skip OOM integration test: load oom_track: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = closer.Close()
+	})
+
+	oomCollector := collector.NewOOMCollector(logger, loader)
+	if err := oomCollector.Start(ctx); err != nil {
+		t.Fatalf("start oom collector: %v", err)
+	}
+	t.Cleanup(oomCollector.Stop)
+
+	victim, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image: "docker.io/library/python:3.12-alpine",
+			Cmd: []string{
+				"python3",
+				"-c",
+				"chunks=[]\nwhile True:\n chunks.append(bytearray(8*1024*1024))\n",
+			},
+			WaitingFor:      wait.ForExit().WithExitTimeout(45 * time.Second),
+			AlwaysPullImage: false,
+			HostConfigModifier: func(hostConfig *dockercontainer.HostConfig) {
+				hostConfig.Memory = 64 * 1024 * 1024
+				hostConfig.MemorySwap = 64 * 1024 * 1024
+			},
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("start oom victim container: %v", err)
+	}
+
+	t.Cleanup(func() {
+		terminateCtx, terminateCancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer terminateCancel()
+		_ = victim.Terminate(terminateCtx)
+	})
+
+	var snap *collector.OOMSnapshot
+	deadline := time.Now().Add(30 * time.Second)
+
+	for time.Now().Before(deadline) {
+		got := oomCollector.Snapshot()
+		var ok bool
+		snap, ok = got.(*collector.OOMSnapshot)
+		if ok && snap.Count > 0 {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	if snap == nil || snap.Count == 0 {
+		t.Fatalf("expected oom collector to capture at least one event")
+	}
+
+	var captured *collector.OOMEventEntry
+	for i := range snap.Events {
+		event := &snap.Events[i]
+		if strings.Contains(event.Comm, "python") || event.OOMScore != 0 {
+			captured = event
+			break
+		}
+	}
+	if captured == nil {
+		t.Fatalf("expected captured OOM event for victim process, got %#v", snap.Events)
+	}
+
+	if captured.PID == 0 {
+		t.Fatalf("expected captured OOM event PID to be set, got %#v", captured)
+	}
+	if captured.Comm == "" {
+		t.Fatalf("expected captured OOM event comm to be set, got %#v", captured)
+	}
+
 	signals := &collector.Signals{
 		Timestamp: time.Now(),
 		Duration:  30 * time.Second,
-		OOM: &collector.OOMSnapshot{
-			Events: []collector.OOMEventEntry{
-				{
-					PID:        1234,
-					Comm:       "oom-victim",
-					OOMScore:   900,
-					RSSPages:   100000,
-					TotalPages: 110000,
-				},
-			},
-			Count: 1,
-		},
+		OOM:       snap,
 	}
 
 	findings := doctor.Evaluate(signals, config.Default().Doctor.Thresholds)
 
-	found := false
 	for _, finding := range findings {
 		if finding.Rule == "oom_kill_occurred" && finding.Severity == doctor.SeverityCritical {
-			found = true
-			if finding.Process != "oom-victim" {
-				t.Fatalf("expected process oom-victim, got %q", finding.Process)
-			}
-			break
+			return
 		}
 	}
 
-	if !found {
-		t.Fatalf("expected oom_kill_occurred finding, got %#v", findings)
-	}
+	t.Fatalf("expected critical oom_kill_occurred finding, got %#v", findings)
 }


### PR DESCRIPTION
## What

Adds an integration test for real OOM kill handling through the OOM collector and doctor rule path.

## Why

Fixes #151

## How

The test starts the OOM eBPF loader/collector, runs a memory-limited container that exceeds its limit, waits for the collector to capture an OOM event, and verifies that `doctor.Evaluate` emits a critical `oom_kill_occurred` finding.

## Testing

* [x] `go build ./...` passes

* [x] `go test ./...` passes

* [x] `go vet ./...` passes

* [x] `golangci-lint run ./...` passes

- [x] Tested locally with: `go test ./...`

- [x] N/A — no eBPF/runtime changes

* [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load

* [ ] `./scripts/verify.sh` passes

## Checklist

* [x] PR title follows Conventional Commits (`test(doctor): exercise oom kill through collector`)
* [x] All commits are DCO-signed (`git commit -s`)
* [x] No unrelated changes pulled in
* [ ] Documentation updated where user-visible behavior changed
* [x] Added/updated tests for new code paths
* [x] N/A — no new doctor rule added
