### PR TITLE
fix(adapter): prefer memory controller in cgroup v1 fallback (#121)  

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 )
 
 // EventMeta holds enrichment metadata that adapters attach to events.
@@ -139,7 +140,8 @@ func parseCgroupPath(content string) string {
 		}
 	}
 
-	// Fallback: return first non-empty path from any controller.
+	// Fallback: cgroup v1 — prefer the memory controller line.
+	var firstPath string
 	for i := 0; i < len(content); {
 		end := i
 		for end < len(content) && content[end] != '\n' {
@@ -152,17 +154,18 @@ func parseCgroupPath(content string) string {
 			i = end
 		}
 
-		// Find the last ':' — path is after it.
-		lastColon := -1
-		for j := len(line) - 1; j >= 0; j-- {
-			if line[j] == ':' {
-				lastColon = j
-				break
+		fields := strings.SplitN(line, ":", 3)
+		if len(fields) < 3 || fields[2] == "" {
+			continue
+		}
+		if firstPath == "" {
+			firstPath = fields[2]
+		}
+		for _, ctrl := range strings.Split(fields[1], ",") {
+			if ctrl == "memory" {
+				return fields[2]
 			}
 		}
-		if lastColon >= 0 && lastColon < len(line)-1 {
-			return line[lastColon+1:]
-		}
 	}
-	return ""
+	return firstPath
 }

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -47,6 +47,31 @@ func TestParseCgroupPath(t *testing.T) {
 			"0::/\n",
 			"/",
 		},
+		{
+			"cgroup v1 memory not first",
+			"5:cpuset:/\n3:pids:/\n12:memory:/kubepods/burstable/pod123\n",
+			"/kubepods/burstable/pod123",
+		},
+		{
+			"cgroup v1 no memory controller",
+			"5:cpuset:/some/path\n3:pids:/some/path\n",
+			"/some/path",
+		},
+		{
+			"cgroup v1 multi-controller line",
+			"7:cpu,cpuacct:/kubepods/pod456\n11:memory:/kubepods/pod456\n",
+			"/kubepods/pod456",
+		},
+		{
+			"cgroup v1 memory with blkio first",
+			"8:blkio:/system.slice/docker-abc.scope\n12:memory:/system.slice/nginx.service\n",
+			"/system.slice/nginx.service",
+		},
+		{
+			"cgroup v1 combined memory controller line",
+			"5:cpu,memory:/kubepods/combined/pod789\n",
+			"/kubepods/combined/pod789",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #121 

## What

This PR corrects the cgroup v1 fallback logic in `parseCgroupPath` to find the path of the hierarchy with the `memory` controller instead of returning the path of whatever controller appears first on a cgroup v1 host.

## How

- Added `strings` package to imports in `internal/adapter/adapter.go`.
- Replaced the fallback pass in `parseCgroupPath` to split each cgroup v1 line into three colon-delimited fields: hierarchy ID, comma-separated controller list, and the path.
- Checks each controller in the controller list. If `"memory"` is found, returns its path immediately.
- If no hierarchy contains `"memory"`, falls back to the path of the first non-empty controller hierarchy.

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] Tested locally with:

- [x] N/A — pure docs/refactor
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [ ] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed
- [x] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`
