### PR TITLE
fix(ai): wire configured max_tokens and temperature onto requests

### DIFF
--- a/internal/ai/analyzer.go
+++ b/internal/ai/analyzer.go
@@ -20,6 +20,9 @@ type DefaultAnalyzer struct {
 	cache    *Cache
 	privacy  PrivacyMode
 	logger   *slog.Logger
+
+	maxTokens   int
+	temperature float64
 }
 
 // AnalyzerConfig holds configuration for constructing a DefaultAnalyzer.
@@ -28,6 +31,9 @@ type AnalyzerConfig struct {
 	Cache    *Cache
 	Privacy  PrivacyMode
 	Logger   *slog.Logger
+
+	MaxTokens   int
+	Temperature float64
 }
 
 // NewAnalyzer creates a DefaultAnalyzer.
@@ -41,10 +47,12 @@ func NewAnalyzer(cfg AnalyzerConfig) *DefaultAnalyzer {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
 	return &DefaultAnalyzer{
-		provider: cfg.Provider,
-		cache:    cfg.Cache,
-		privacy:  privacy,
-		logger:   logger,
+		provider:    cfg.Provider,
+		cache:       cfg.Cache,
+		privacy:     privacy,
+		logger:      logger,
+		maxTokens:   cfg.MaxTokens,
+		temperature: cfg.Temperature,
 	}
 }
 
@@ -73,6 +81,8 @@ func (a *DefaultAnalyzer) Analyze(ctx context.Context, req doctor.AnalysisReques
 	completion, err := a.provider.Complete(ctx, CompletionRequest{
 		SystemPrompt: SystemPrompt,
 		UserPrompt:   userPrompt,
+		MaxTokens:    a.maxTokens,
+		Temperature:  a.temperature,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("AI provider %s: %w", a.provider.Name(), err)

--- a/internal/ai/analyzer_test.go
+++ b/internal/ai/analyzer_test.go
@@ -36,12 +36,15 @@ type scriptedProvider struct {
 	model  string
 	err    error
 	calls  atomic.Uint64
+
+	lastReq CompletionRequest
 }
 
 func (p *scriptedProvider) Name() string { return "scripted" }
 
-func (p *scriptedProvider) Complete(_ context.Context, _ CompletionRequest) (*CompletionResponse, error) {
+func (p *scriptedProvider) Complete(_ context.Context, req CompletionRequest) (*CompletionResponse, error) {
 	p.calls.Add(1)
+	p.lastReq = req
 	if p.err != nil {
 		return nil, p.err
 	}
@@ -89,6 +92,37 @@ func TestAnalyzerUsesDiscardLoggerWhenNil(t *testing.T) {
 	}
 	if resp.Summary != "ok" {
 		t.Errorf("Summary = %q, want ok", resp.Summary)
+	}
+}
+
+func TestAnalyzerWiresConfiguredMaxTokensAndTemperature(t *testing.T) {
+	cases := []struct {
+		name        string
+		maxTokens   int
+		temperature float64
+	}{
+		{"configured values ride the request", 2048, 0.7},
+		{"zero stays zero so provider keeps its default", 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			prov := &scriptedProvider{text: `{"summary":"ok"}`}
+			a := NewAnalyzer(AnalyzerConfig{
+				Provider:    prov,
+				Logger:      newSilentAILogger(),
+				MaxTokens:   c.maxTokens,
+				Temperature: c.temperature,
+			})
+			if _, err := a.Analyze(context.Background(), doctor.AnalysisRequest{Signals: emptySignals()}); err != nil {
+				t.Fatalf("Analyze error: %v", err)
+			}
+			if prov.lastReq.MaxTokens != c.maxTokens {
+				t.Errorf("request MaxTokens = %d, want %d", prov.lastReq.MaxTokens, c.maxTokens)
+			}
+			if prov.lastReq.Temperature != c.temperature {
+				t.Errorf("request Temperature = %v, want %v", prov.lastReq.Temperature, c.temperature)
+			}
+		})
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -453,10 +453,12 @@ func buildAnalyzer(c *config.Config, logger *slog.Logger) (doctor.Analyzer, erro
 	}
 
 	return ai.NewAnalyzer(ai.AnalyzerConfig{
-		Provider: provider,
-		Cache:    cache,
-		Privacy:  privacy,
-		Logger:   logger,
+		Provider:    provider,
+		Cache:       cache,
+		Privacy:     privacy,
+		Logger:      logger,
+		MaxTokens:   aiCfg.MaxTokens,
+		Temperature: aiCfg.Temperature,
 	}), nil
 }
 


### PR DESCRIPTION
## What

`DefaultAnalyzer.Analyze` built the `CompletionRequest` without `MaxTokens` or `Temperature`, so the documented request-level fields never carried through the only real caller. anyone relying on per-request values had them silently dropped.

## Why

Fixes #120

## How

added `MaxTokens` and `Temperature` to `AnalyzerConfig` and `DefaultAnalyzer`, set them on the request in `Analyze`, and `buildAnalyzer` in `doctor.go` passes the configured values through. zero stays zero so providers keep their own fallback intact.

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] Tested locally with: <!-- e.g. `sudo ./bin/kerno doctor --duration 5s` -->

- [x] N/A - pure docs/refactor

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [ ] Documentation updated where user-visible behavior change
- [x] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `s