### PR TITLE
feat(ci): add OpenSSF Scorecard security scan workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: OpenSSF Scorecard Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF Results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload Scorecard Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5


### PR DESCRIPTION
## What

This pull request adds a dedicated GitHub Actions workflow to automatically run OpenSSF Scorecard security analysis for the repository.

The workflow generates a SARIF report, uploads it to GitHub Code Scanning, and stores the results as a workflow artifact for future reference.

## Why

Fixes #237 

Automating OpenSSF Scorecard scans improves repository security by continuously evaluating supply chain security best practices such as GitHub Actions security, workflow permissions, branch protection, dependency management, and repository configuration.

## How

- Added a new `.github/workflows/scorecard.yml` workflow.
- Uses the official `ossf/scorecard-action`.
- Generates security analysis in SARIF format.
- Uploads SARIF results to GitHub Code Scanning.
- Uploads the generated report as a GitHub Actions artifact.
- Supports scheduled execution and manual workflow dispatch.

## Testing

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes
- [x] N/A — workflow-only change (no application or eBPF code modified)

## Checklist

- [x] PR title follows Conventional Commits (`feat(ci): ...`)
- [x] All commits are DCO-signed
- [x] No unrelated changes pulled in
- [ ] Documentation updated where user-visible behavior changed
- [ ] Added/updated tests for new code paths
- [x] No doctor rule changes