### PR TITLE
ci: add Trivy vulnerability scanning workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,50 @@
+# Copyright 2026 Optiqor contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  trivy:
+    name: Trivy filesystem scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: "0"
+
+      - name: Upload Trivy scan results
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-filesystem
+
+      - name: Upload Trivy SARIF artifact
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-results
+          path: trivy-results.sarif


### PR DESCRIPTION
  ## What

  Adds a dedicated GitHub Actions security workflow that runs Trivy filesystem vulnerability scanning and
  uploads SARIF results to GitHub Security.

  ## Why

  Fixes #234

  ## How

  The workflow runs on pushes to `main`, pull requests targeting `main`, and manual `workflow_dispatch`. It
  uses `aquasecurity/trivy-action` to generate a SARIF report, then uploads it with `github/codeql-action/
  upload-sarif`; forked PRs upload the SARIF as an artifact because they generally cannot write code scanning
  results.

  ## Testing

  - [ ] `go build ./...` passes
  - [ ] `go test ./...` passes
  - [ ] `go vet ./...` passes
  - [ ] `golangci-lint run ./...` passes
  - [x] Tested locally with: `git diff --check`

  <!-- Required for changes touching internal/bpf/, internal/collector/, internal/doctor/. -->

  - [x] N/A — CI workflow only
  - [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
  - [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

  ## Checklist

  - [x] PR title follows Conventional Commits (`feat(scope): subject`)
  - [x] All commits are DCO-signed (`git commit -s`)
  - [x] No unrelated changes pulled in
  - [x] Documentation updated where user-visible behavior changed
  - [x] Added/updated tests for new code paths
  - [x] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`