### PR TITLE
docs: add build toolchain note

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,11 +666,13 @@ See [TODO.md](TODO.md) for the full plan. Headlines:
 
 ## Building from Source
 
+> **Note:** If you update Go or install new build dependencies after cloning the repository, run a clean rebuild to ensure all generated binaries and artifacts use the latest toolchain.
+
 ```bash
 # Requirements: Go 1.25+
 # Optional for real eBPF: clang 14+, libbpf-dev, llvm, bpftool
 
-make build          # Build binary (uses BPF stubs - no clang needed)
+make build        # Build binary (uses BPF stubs - no clang needed)
 make generate       # Run bpf2go to produce *_bpfel.go from C sources
 make bpf            # Compile eBPF C programs to .o
 make bpf-verify     # Build the standalone kernel-verifier load harness


### PR DESCRIPTION
## What

Added a documentation note recommending a clean rebuild after updating the Go toolchain or installing new build dependencies. This helps contributors avoid build inconsistencies caused by stale artifacts.

## Why

Fixes #None (just a documentation quick fix)

## How

Added a short note to the **Building from Source** section without modifying the existing build workflow or commands.

## Testing

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes
- [x] Tested locally with: Reviewed the updated README formatting and verified the documentation renders correctly.

- [x] N/A — pure docs/refactor
- [ ] `sudo ./bin/bpf-verify --read 5s` confirms 6/6 programs still load
- [ ] `./scripts/verify.sh` passes (or specific phase: `./scripts/verify.sh quality`)

## Checklist

- [x] PR title follows Conventional Commits (`feat(scope): subject`)
- [ ] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed
- [ ] Added/updated tests for new code paths
- [ ] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh`